### PR TITLE
wrong variable in comparison code for verification

### DIFF
--- a/src/tutorials/average_pool2d/average_pool2d_nki_kernels.py
+++ b/src/tutorials/average_pool2d/average_pool2d_nki_kernels.py
@@ -83,7 +83,7 @@ if __name__ == "__main__":
 
   print(in_tensor, out_nki, out_np)
 
-  match = (out_nki == out_nki).all()
+  match = (out_nki == out_np).all()
 
   if match:
     print("NKI and NumPy match")


### PR DESCRIPTION
the code will always print "NKI and NumPy match" even when they might actually differ. The comparison needs to be between the NKI output (out_nki) and the NumPy output (out_np) to properly verify if they produce the same results.

Not sure if this shows up in a doc or test anywhere else.


### Testing:

Please see detailed unit test requirements in the [CONTRIBUTING.md](https://github.com/aws-neuron/nki-samples/blob/main/CONTRIBUTING.md)
- [X] The change FIXES the numeric checking
- [ ] The change is covered by numeric check using `nki.baremetal`
- [ ] The change is covered by performance benchmark test using `nki.benchmark`
- [ ] The change is covered by end-to-end integration test

### Pull Request Checklist

- [ x] I have filled in all the required field in the template
- [ ] I have tested locally that all the tests pass.  (I just eyeballed this, but I'm pretty confident)
- [x ] By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.

