### PR TITLE
[Bug Fix] there should be no addition of result of the first matmul t…

### DIFF
--- a/src/nki_samples/reference/allocated_attention.py
+++ b/src/nki_samples/reference/allocated_attention.py
@@ -211,7 +211,7 @@ def allocated_fused_self_attn_for_SD_small_head_size(q_ref, k_ref, v_ref,
             on_true_tile=qk_psum[i_interleave_grp, i_k_seq_tile,ip_qk, if_qk], on_false_value=-9984.0, dtype=kernel_dtype)
         else:
           # Copy result to SBUF and find partial maximum for softmax
-          qk_res_buf[i_interleave_grp, ip_qk, i_k_seq_tile * k_seq_tile_size + if_qk] = nisa.tensor_scalar_reduce(data=qk_psum[i_interleave_grp, i_k_seq_tile,ip_qk, if_qk], op0=np.add, operand0=1.0,
+          qk_res_buf[i_interleave_grp, ip_qk, i_k_seq_tile * k_seq_tile_size + if_qk] = nisa.tensor_scalar_reduce(data=qk_psum[i_interleave_grp, i_k_seq_tile,ip_qk, if_qk], op0=np.mul , operand0=1.0,
               reduce_op=np.max, reduce_res=neg_max_res[i_interleave_grp, ip_max, i_k_seq_tile], dtype=kernel_dtype)
 
       # Find global max from tiles


### PR DESCRIPTION
…o 1.0 in attention kernel

### Issue #, if available:

Every element of a tile was being added to 1 after the first matmul when reading its result from PSUM.

### Description of changes:
Multiply by 1 instead

### Testing:

Please see detailed unit test requirements in the [CONTRIBUTING.md](https://github.com/aws-neuron/nki-samples/blob/main/CONTRIBUTING.md)

- [x ] The change is covered by numeric check using `nki.baremetal`
- [x ] The change is covered by performance benchmark test using `nki.benchmark`
- [x ] The change is covered by end-to-end integration test

### Pull Request Checklist

- [ x] I have filled in all the required field in the template
- [ x] I have tested locally that all the tests pass
- [x ] By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.

