### PR TITLE
Fix hardcoded gen3 check to be greater or equal to gen3

### DIFF
--- a/src/nki_samples/reference/allocated_fused_linear.py
+++ b/src/nki_samples/reference/allocated_fused_linear.py
@@ -86,7 +86,7 @@ def allocated_fused_rms_norm_qkv(hidden, weights, norm_dtype=nl.float32, eps=1e-
         square_sum[...] = nisa.activation(op=nl.rsqrt, data=square_sum[...], bias=bias_placeholder[...], mask=((2*i + i_interleave_grp) * pmax < seqlen))
 
         # all PE array ops must output to FP32 on trn1 but must match input dtype in trn2
-        if nisa.get_nc_version() == nisa.nc_version.gen3:
+        if nisa.get_nc_version() >= nisa.nc_version.gen3:
           transpose_res_psum = nl.ndarray((NUM_TRANSP_TILES, par_dim(pmax), 4*pmax), dtype=weights.dtype,
                                           buffer=ncc.psum.mod_alloc(base_bank=0, num_bank_tiles=(1,))) # FIXME: perf is better when all tiles are on bank 0?
         else:

--- a/src/nki_samples/reference/attention.py
+++ b/src/nki_samples/reference/attention.py
@@ -45,7 +45,7 @@ class FlashConfig:
 def transpose_p_local(p_local_transposed, p_local, LARGE_TILE_SZ, use_dma_transpose=False):
   for i in nl.affine_range(LARGE_TILE_SZ // 512):
     # Temporarily disable use_dma_tranpose by default until we stablized it
-    if use_dma_transpose and nisa.get_nc_version() == nisa.nc_version.gen3:
+    if use_dma_transpose and nisa.get_nc_version() >= nisa.nc_version.gen3:
       p_local_t_tmp = nl.ndarray((par_dim(128), 512), buffer=nl.sbuf, dtype=p_local.dtype)
     else:
       p_local_t_tmp = nl.ndarray((par_dim(128), 512), buffer=nl.psum, dtype=np.float32)
@@ -54,7 +54,7 @@ def transpose_p_local(p_local_transposed, p_local, LARGE_TILE_SZ, use_dma_transp
       j_128_slice = nl.ds(j * 128, 128)
       i_j_128_slice = nl.ds(i * 512 + j * 128, 128)
 
-      if use_dma_transpose and nisa.get_nc_version() == nisa.nc_version.gen3:
+      if use_dma_transpose and nisa.get_nc_version() >= nisa.nc_version.gen3:
         p_local_t_tmp[:, j_128_slice] = nisa.dma_transpose(
           p_local[:, i_j_128_slice])
       else:
@@ -280,7 +280,7 @@ def load_v_tile(v_hbm_tile, cur_v_tile, j, v_i, config):
       dtype=cur_v_tile.dtype)
     return
 
-  if nisa.get_nc_version() == nisa.nc_version.gen3:
+  if nisa.get_nc_version() >= nisa.nc_version.gen3:
     cur_v_tile_transposed = nisa.dma_transpose(
       v_hbm_tile[:, nl.ds(j * LARGE_TILE_SZ + B_P_SIZE * v_i, B_P_SIZE)])
     cur_v_tile[v_i, :, :] = nisa.tensor_copy(cur_v_tile_transposed,


### PR DESCRIPTION
### Issue #, if available:

N/A

### Description of changes:

Fix hardcoded gen3 check to be greater or equal to gen3 so that it is future compatible. 

### Testing:

Please see detailed unit test requirements in the [CONTRIBUTING.md](https://github.com/aws-neuron/nki-samples/blob/main/CONTRIBUTING.md)

- [x] The change is covered by numeric check using `nki.baremetal`
- [x] The change is covered by performance benchmark test using `nki.benchmark`
- [x] The change is covered by end-to-end integration test

### Pull Request Checklist

- [x] I have filled in all the required field in the template
- [x] I have tested locally that all the tests pass
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.

