### PR TITLE
Add interpolation kernels (only supports 2x and align_corners=False)

### DIFF
--- a/contributed/interpolate_bilinear_fwd.py
+++ b/contributed/interpolate_bilinear_fwd.py
@@ -84,22 +84,18 @@ def interpolate_bilinear_2x_fwd(src_arr: nt.tensor, chunk_size: int = 10) -> Non
             ### Core region
             weight_2d = weight_1d**2
 
-            i_p = nl.arange(P_TILE_SIZE)[:, None, None, None, None]
-
-            i_h_dst = (2 * nl.arange(h_tile_size_src - 1)[None, None, None, :, None] + 1) + nl.arange(2)[None, :, None, None, None]
-            i_w_dst = (2 * nl.arange(w_src - 1)[None, None, None, None, :] + 1) + nl.arange(2)[None, None, :, None, None]
+            i_p, i_hx, i_wx, i_hy, i_wy = nl.mgrid[0:P_TILE_SIZE, 0:2, 0:2, 0:(h_tile_size_src-1), 0:(w_src-1)]
+            i_h_dst = (2 * i_hy + 1) + i_hx
+            i_w_dst = (2 * i_wy + 1) + i_wx
             
-            i_h_src_056 = nl.arange(h_tile_size_src - 1)[None, None, None, :, None] + nl.arange(2)[None, :, None, None, None]
-            i_w_src_056 = nl.arange(w_src - 1)[None, None, None, None, :] + nl.arange(2)[None, None, :, None, None]
-
-            i_h_src_006 = nl.arange(h_tile_size_src - 1)[None, None, None, :, None] + (-1 * nl.arange(2)[None, :, None, None, None] + 1)
-            i_w_src_006 = nl.arange(w_src - 1)[None, None, None, None, :] + (-1 * nl.arange(2)[None, None, :, None, None] + 1)
-
-            i_h_src_018_h = nl.arange(h_tile_size_src - 1)[None, None, None, :, None] + (-1 * nl.arange(2)[None, :, None, None, None] + 1)
-            i_w_src_018_h = nl.arange(w_src - 1)[None, None, None, None, :] + nl.arange(2)[None, None, :, None, None]
-
-            i_h_src_018_w = nl.arange(h_tile_size_src - 1)[None, None, None, :, None] + nl.arange(2)[None, :, None, None, None]
-            i_w_src_018_w = nl.arange(w_src - 1)[None, None, None, None, :] + (-1 * nl.arange(2)[None, None, :, None, None] + 1)
+            i_h_src_056 = i_hy + i_hx
+            i_w_src_056 = i_wy + i_wx
+            i_h_src_006 = i_hy + (-1 * i_hx + 1)
+            i_w_src_006 = i_wy + (-1 * i_wx + 1)
+            i_h_src_018_h = i_hy + (-1 * i_hx + 1)
+            i_w_src_018_h = i_wy + i_wx
+            i_h_src_018_w = i_hy + i_hx
+            i_w_src_018_w = i_wy + (-1 * i_wx + 1)
             
             out_tile[i_p, i_h_dst, i_w_dst] = (
                 9 * weight_2d * in_tile[i_p, i_h_src_056, i_w_src_056] + \
@@ -110,7 +106,7 @@ def interpolate_bilinear_2x_fwd(src_arr: nt.tensor, chunk_size: int = 10) -> Non
         
             ### Edges
             ## Upper & lower edges, i.e. h=0 or h=h_dst-1 (corners excluded)
-            i_p, i_wx, i_h, i_wy = nl.mgrid[0:P_TILE_SIZE, 0:2, 0:2, 0:(w_src - 1)]
+            i_p, i_wx, i_h, i_wy = nl.mgrid[0:P_TILE_SIZE, 0:2, 0:2, 0:(w_src-1)]
 
             i_h_dst = (h_tile_size_dst - 1) * i_h
             i_w_dst = (2 * i_wy + 1) + i_wx
@@ -185,7 +181,7 @@ def benchmark_kernel():
 
 def main():
   check_correct()
-# benchmark_kernel()
+  benchmark_kernel()
 
 if __name__ == "__main__":
   main()

--- a/contributed/interpolate_bilinear_fwd.py
+++ b/contributed/interpolate_bilinear_fwd.py
@@ -109,9 +109,9 @@ def interpolate_bilinear_2x_fwd(src_arr: nt.tensor, chunk_size: int = 10) -> Non
             )
         
             ### Edges
+            ## Upper & lower edges, i.e. h=0 or h=h_dst-1 (corners excluded)
             i_p, i_wx, i_h, i_wy = nl.mgrid[0:P_TILE_SIZE, 0:2, 0:2, 0:(w_src - 1)]
 
-            ## Upper & lower edges, i.e. h=0 or h=h_dst-1 (corners excluded)
             i_h_dst = (h_tile_size_dst - 1) * i_h
             i_w_dst = (2 * i_wy + 1) + i_wx
             
@@ -125,14 +125,14 @@ def interpolate_bilinear_2x_fwd(src_arr: nt.tensor, chunk_size: int = 10) -> Non
             )
         
             ## Right & left edges, i.e. w=0 or w=w_dst-1 (corners excluded)
-            i_p = nl.arange(P_TILE_SIZE)[:, None, None, None]
+            i_p, i_hx, i_w, i_hy = nl.mgrid[0:P_TILE_SIZE, 0:2, 0:2, 0:(h_tile_size_src-1)]
 
-            i_h_dst = (2 * nl.arange(h_tile_size_src - 1)[None, None, None, :] + 1) + nl.arange(2)[None, :, None, None]
-            i_w_dst = ((w_dst - 1) * nl.arange(2)[None, None, :, None])
+            i_h_dst = (2 * i_hy + 1) + i_hx
+            i_w_dst = (w_dst - 1) * i_w
             
-            i_h_src_075 = nl.arange(h_tile_size_src - 1)[None, None, None, :] + nl.arange(2)[None, :, None, None]
-            i_h_src_025 = nl.arange(h_tile_size_src - 1)[None, None, None, :] + (-1 * nl.arange(2)[None, :, None, None] + 1)
-            i_w_src = ((w_src - 1) * nl.arange(2)[None, None, :, None])
+            i_h_src_075 = i_hy + i_hx
+            i_h_src_025 = i_hy + (-1 * i_hx + 1)
+            i_w_src = (w_src - 1) * i_w
             
             out_tile[i_p, i_h_dst, i_w_dst] = (
                 3 * weight_1d * in_tile[i_p, i_h_src_075, i_w_src] + \

--- a/contributed/interpolate_bilinear_fwd.py
+++ b/contributed/interpolate_bilinear_fwd.py
@@ -84,18 +84,18 @@ def interpolate_bilinear_2x_fwd(src_arr: nt.tensor, chunk_size: int = 10) -> Non
             ### Core region
             weight_2d = weight_1d**2
 
-            i_p, i_hx, i_wx, i_hy, i_wy = nl.mgrid[0:P_TILE_SIZE, 0:2, 0:2, 0:(h_tile_size_src-1), 0:(w_src-1)]
-            i_h_dst = (2 * i_hy + 1) + i_hx
-            i_w_dst = (2 * i_wy + 1) + i_wx
+            i_p, i_h_x, i_w_x, i_h_y, i_w_y = nl.mgrid[0:P_TILE_SIZE, 0:2, 0:2, 0:(h_tile_size_src-1), 0:(w_src-1)]
+            i_h_dst = (2 * i_h_y + 1) + i_h_x
+            i_w_dst = (2 * i_w_y + 1) + i_w_x
             
-            i_h_src_056 = i_hy + i_hx
-            i_w_src_056 = i_wy + i_wx
-            i_h_src_006 = i_hy + (-1 * i_hx + 1)
-            i_w_src_006 = i_wy + (-1 * i_wx + 1)
-            i_h_src_018_h = i_hy + (-1 * i_hx + 1)
-            i_w_src_018_h = i_wy + i_wx
-            i_h_src_018_w = i_hy + i_hx
-            i_w_src_018_w = i_wy + (-1 * i_wx + 1)
+            i_h_src_056 = i_h_y + i_h_x
+            i_w_src_056 = i_w_y + i_w_x
+            i_h_src_006 = i_h_y + (-1 * i_h_x + 1)
+            i_w_src_006 = i_w_y + (-1 * i_w_x + 1)
+            i_h_src_018_h = i_h_y + (-1 * i_h_x + 1)
+            i_w_src_018_h = i_w_y + i_w_x
+            i_h_src_018_w = i_h_y + i_h_x
+            i_w_src_018_w = i_w_y + (-1 * i_w_x + 1)
             
             out_tile[i_p, i_h_dst, i_w_dst] = (
                 9 * weight_2d * in_tile[i_p, i_h_src_056, i_w_src_056] + \
@@ -106,14 +106,14 @@ def interpolate_bilinear_2x_fwd(src_arr: nt.tensor, chunk_size: int = 10) -> Non
         
             ### Edges
             ## Upper & lower edges, i.e. h=0 or h=h_dst-1 (corners excluded)
-            i_p, i_wx, i_h, i_wy = nl.mgrid[0:P_TILE_SIZE, 0:2, 0:2, 0:(w_src-1)]
+            i_p, i_w_x, i_h, i_w_y = nl.mgrid[0:P_TILE_SIZE, 0:2, 0:2, 0:(w_src-1)]
 
             i_h_dst = (h_tile_size_dst - 1) * i_h
-            i_w_dst = (2 * i_wy + 1) + i_wx
+            i_w_dst = (2 * i_w_y + 1) + i_w_x
             
             i_h_src = (h_tile_size_src - 1) * i_h
-            i_w_src_075 = i_wy + i_wx
-            i_w_src_025 = i_wy + (-1 * i_wx + 1)
+            i_w_src_075 = i_w_y + i_w_x
+            i_w_src_025 = i_w_y + (-1 * i_w_x + 1)
             
             out_tile[i_p, i_h_dst, i_w_dst] = (
                 3 * weight_1d * in_tile[i_p, i_h_src, i_w_src_075] + \
@@ -121,13 +121,13 @@ def interpolate_bilinear_2x_fwd(src_arr: nt.tensor, chunk_size: int = 10) -> Non
             )
         
             ## Right & left edges, i.e. w=0 or w=w_dst-1 (corners excluded)
-            i_p, i_hx, i_w, i_hy = nl.mgrid[0:P_TILE_SIZE, 0:2, 0:2, 0:(h_tile_size_src-1)]
+            i_p, i_h_x, i_w, i_h_y = nl.mgrid[0:P_TILE_SIZE, 0:2, 0:2, 0:(h_tile_size_src-1)]
 
-            i_h_dst = (2 * i_hy + 1) + i_hx
+            i_h_dst = (2 * i_h_y + 1) + i_h_x
             i_w_dst = (w_dst - 1) * i_w
             
-            i_h_src_075 = i_hy + i_hx
-            i_h_src_025 = i_hy + (-1 * i_hx + 1)
+            i_h_src_075 = i_h_y + i_h_x
+            i_h_src_025 = i_h_y + (-1 * i_h_x + 1)
             i_w_src = (w_src - 1) * i_w
             
             out_tile[i_p, i_h_dst, i_w_dst] = (

--- a/contributed/interpolate_bilinear_fwd.py
+++ b/contributed/interpolate_bilinear_fwd.py
@@ -1,0 +1,194 @@
+"""
+Copyright (c) 2025, Amazon.com. All Rights Reserved
+
+WARNING: These kernels:
+   - Are tested only against internal nightly builds
+   - May not be compatible with public NeuronSDK releases
+   - Have not been extensively tested across all input configurations
+   - Carry no compatibility guarantees
+   - The behavior of these kernels may be modified without prior notice
+"""
+
+import math
+import numpy as np
+import torch
+
+from neuronxcc import nki
+import neuronxcc.nki.language as nl
+import neuronxcc.nki.typing as nt
+from neuronxcc.nki import benchmark
+
+# For debugging
+# import os
+# os.environ["NEURON_FRAMEWORK_DEBUG"] = "1"
+# os.environ["NEURON_CC_FLAGS"]= " --disable-dge "
+
+@nki.jit
+def interpolate_bilinear_2x_fwd(src_arr: nt.tensor, chunk_size: int = 10) -> None:
+    """
+    This function performs a forward-pass linear interpolation on a 4D input array for `scaling_factor=2` and `align_corners=False`.
+
+    Source array N & C dimensions are mapped to the SBUF partition dimension. H & W dimensions are mapped to the 
+    SBUF free dimension. The kernel chunks the source array along the H dimension in chunks of `chunk_size` rows. 
+    From a physical memory perspective, the kernel therefore operates on source array tiles of size (pmax, chunk_size * w_src).
+
+    Args:
+        src_arr (nt.tensor): Input HBM tensor of shape (N, C, H_src, W_src).
+        chunk_size (int): Size of the chunk along the H free dimension.
+    """
+    P_TILE_SIZE = nl.tile_size.pmax # 128
+
+    n_src, c_src, h_src, w_src = src_arr.shape
+    n_dst, c_dst, h_dst, w_dst = n_src, c_src, h_src * 2, w_src * 2
+
+    assert n_src == n_dst, "Input batch and output batch sizes must be identical"
+    assert c_src == c_dst, "Input channel and output channel sizes must be identical"
+    assert h_dst == 2 * h_src, "Output height must be twice the input height"
+    assert w_dst == 2 * w_src, "Output width must be twice the input width"
+    n, c = n_src, c_src
+
+    weight_1d = 1 / 4 # specific to scaling_factor=2.0 & align_corners=False
+
+    src_arr = src_arr.reshape((n * c, h_src, w_src))
+    dst_arr = nl.ndarray(
+        [n_dst * c_dst, h_dst, w_dst], 
+        dtype=src_arr.dtype,
+        buffer=nl.shared_hbm
+    )
+    
+    wdw_size = chunk_size
+    step_size = wdw_size - 1
+
+    for h in nl.static_range(math.ceil((h_src - wdw_size) / step_size) + 1):
+        h_start_hbm_src = max(0, h * step_size) 
+        h_end_hbm_src = min(wdw_size + h * step_size, h_src)
+        
+        h_tile_size_src = h_end_hbm_src - h_start_hbm_src
+        h_tile_size_dst = 2 * h_tile_size_src
+        
+        h_start_tile_dst = 1 if h_start_hbm_src else 0
+        h_end_tile_dst = h_tile_size_dst
+        
+        h_start_hbm_dst = 2 * h_start_hbm_src + 1 if h_start_hbm_src else 0
+        h_end_hbm_dst = 2 * h_end_hbm_src
+
+        for p in nl.affine_range(math.ceil(n * c / P_TILE_SIZE)):
+            out_tile = nl.ndarray([P_TILE_SIZE, h_tile_size_dst, w_dst], dtype=src_arr.dtype, buffer=nl.sbuf)
+
+            ### Load input array from HBM
+            i_p = p * P_TILE_SIZE + nl.arange(P_TILE_SIZE)[:, None, None]
+            i_h = nl.arange(h_start_hbm_src, h_end_hbm_src)[None, :, None]
+            i_w = nl.arange(w_src)[None, None, :]
+
+            in_tile = nl.load(src_arr[i_p, i_h, i_w], mask=(i_p < n * c))
+
+            ### Core region
+            weight_2d = weight_1d**2
+
+            i_p = nl.arange(P_TILE_SIZE)[:, None, None, None, None]
+
+            i_h_dst = (2 * nl.arange(h_tile_size_src - 1)[None, None, None, :, None] + 1) + nl.arange(2)[None, :, None, None, None]
+            i_w_dst = (2 * nl.arange(w_src - 1)[None, None, None, None, :] + 1) + nl.arange(2)[None, None, :, None, None]
+            
+            i_h_src_056 = nl.arange(h_tile_size_src - 1)[None, None, None, :, None] + nl.arange(2)[None, :, None, None, None]
+            i_w_src_056 = nl.arange(w_src - 1)[None, None, None, None, :] + nl.arange(2)[None, None, :, None, None]
+
+            i_h_src_006 = nl.arange(h_tile_size_src - 1)[None, None, None, :, None] + (-1 * nl.arange(2)[None, :, None, None, None] + 1)
+            i_w_src_006 = nl.arange(w_src - 1)[None, None, None, None, :] + (-1 * nl.arange(2)[None, None, :, None, None] + 1)
+
+            i_h_src_018_h = nl.arange(h_tile_size_src - 1)[None, None, None, :, None] + (-1 * nl.arange(2)[None, :, None, None, None] + 1)
+            i_w_src_018_h = nl.arange(w_src - 1)[None, None, None, None, :] + nl.arange(2)[None, None, :, None, None]
+
+            i_h_src_018_w = nl.arange(h_tile_size_src - 1)[None, None, None, :, None] + nl.arange(2)[None, :, None, None, None]
+            i_w_src_018_w = nl.arange(w_src - 1)[None, None, None, None, :] + (-1 * nl.arange(2)[None, None, :, None, None] + 1)
+            
+            out_tile[i_p, i_h_dst, i_w_dst] = (
+                9 * weight_2d * in_tile[i_p, i_h_src_056, i_w_src_056] + \
+                3 * weight_2d * in_tile[i_p, i_h_src_018_h, i_w_src_018_h] + \
+                3 * weight_2d * in_tile[i_p, i_h_src_018_w, i_w_src_018_w] + \
+                1 * weight_2d * in_tile[i_p, i_h_src_006, i_w_src_006]
+            )
+        
+            ### Edges
+            i_p = nl.arange(P_TILE_SIZE)[:, None, None, None]
+
+            ## Upper & lower edges, i.e. h=0 or h=h_dst-1 (corners excluded)
+            i_h_dst = ((h_tile_size_dst - 1) * nl.arange(2)[None, None, :, None])
+            i_w_dst = (2 * nl.arange(w_src - 1)[None, None, None, :] + 1) + nl.arange(2)[None, :, None, None]
+            
+            i_h_src = ((h_tile_size_src - 1) * nl.arange(2)[None, None, :, None])
+            i_w_src_075 = nl.arange(w_src - 1)[None, None, None, :] + nl.arange(2)[None, :, None, None]
+            i_w_src_025 = nl.arange(w_src - 1)[None, None, None, :] + (-1 * nl.arange(2)[None, :, None, None] + 1)
+            
+            out_tile[i_p, i_h_dst, i_w_dst] = (
+                3 * weight_1d * in_tile[i_p, i_h_src, i_w_src_075] + \
+                1 * weight_1d * in_tile[i_p, i_h_src, i_w_src_025]
+            )
+        
+            ## Right & left edges, i.e. w=0 or w=w_dst-1 (corners excluded)
+            i_h_dst = (2 * nl.arange(h_tile_size_src - 1)[None, None, None, :] + 1) + nl.arange(2)[None, :, None, None]
+            i_w_dst = ((w_dst - 1) * nl.arange(2)[None, None, :, None])
+            
+            i_h_src_075 = nl.arange(h_tile_size_src - 1)[None, None, None, :] + nl.arange(2)[None, :, None, None]
+            i_h_src_025 = nl.arange(h_tile_size_src - 1)[None, None, None, :] + (-1 * nl.arange(2)[None, :, None, None] + 1)
+            i_w_src = ((w_src - 1) * nl.arange(2)[None, None, :, None])
+            
+            out_tile[i_p, i_h_dst, i_w_dst] = (
+                3 * weight_1d * in_tile[i_p, i_h_src_075, i_w_src] + \
+                1 * weight_1d * in_tile[i_p, i_h_src_025, i_w_src]
+            )
+        
+            ## Corners
+            i_p = nl.arange(P_TILE_SIZE)[:, None, None]
+
+            i_h_dst = ((h_tile_size_dst - 1) * nl.arange(2)[None, None, :])
+            i_w_dst = ((w_dst - 1) * nl.arange(2)[None, :, None])
+            
+            i_h_src = ((h_tile_size_src - 1) * nl.arange(2)[None, None, :])
+            i_w_src = ((w_src - 1) * nl.arange(2)[None, :, None])
+        
+            out_tile[i_p, i_h_dst, i_w_dst] = in_tile[i_p, i_h_src, i_w_src]
+
+            ### Write output array to HBM
+            i_p_tile = nl.arange(P_TILE_SIZE)[:, None, None]
+            i_h_tile = nl.arange(h_start_tile_dst, h_end_tile_dst)[None, :, None]
+            i_p_hbm = p * P_TILE_SIZE + nl.arange(P_TILE_SIZE)[:, None, None]
+            i_h_hbm = nl.arange(h_start_hbm_dst, h_end_hbm_dst)[None, :, None]
+            i_w = nl.arange(w_dst)[None, None, :]
+
+            nl.store(dst_arr[i_p_hbm, i_h_hbm, i_w], value=out_tile[i_p_tile, i_h_tile, i_w], mask=(i_p_hbm < n * c))
+
+    dst_arr = dst_arr.reshape((n, c, h_dst, w_dst))
+    return dst_arr
+
+
+def check_correct():
+  print("\nChecking Correctness")
+  N, C, W, H = 2, 64, 128, 128 
+  src_arr = np.random.random_sample([N, C, W, H]).astype(np.float32)
+  
+  baremetal_func = nki.baremetal()(interpolate_bilinear_2x_fwd)
+  dst_arr = baremetal_func(src_arr)
+  src_arr = torch.from_numpy(src_arr)
+  nki_dst_arr = torch.from_numpy(dst_arr)
+  torch_dst_arr = torch.nn.functional.interpolate(src_arr, scale_factor=2, mode="bilinear")
+  print("Is close: ", torch.allclose(nki_dst_arr, torch_dst_arr, atol=1e-4, rtol=1e-2))
+
+def benchmark_kernel():
+  print("\nBenchmarking")
+  N, C, W, H = 128, 64, 128, 128
+  src_arr = np.random.random_sample([N, C, W, H]).astype(np.float32)
+
+  benchmark_kernel = benchmark(warmup=10, iters=100, save_neff_name='file.neff', save_trace_name='profile.ntff')(interpolate_bilinear_2x_fwd)
+  _ = benchmark_kernel(src_arr)
+  metrics = benchmark_kernel.benchmark_result.nc_latency
+  print("Latency (P50): " + str(metrics.get_latency_percentile(50)))
+  print("Latency (P99): " + str(metrics.get_latency_percentile(99)))
+
+
+def main():
+  check_correct()
+  benchmark_kernel()
+
+if __name__ == "__main__":
+  main()

--- a/contributed/interpolate_trilinear_fwd.py
+++ b/contributed/interpolate_trilinear_fwd.py
@@ -1,0 +1,344 @@
+"""
+Copyright (c) 2025, Amazon.com. All Rights Reserved
+
+Authors: Mun Kim and Pierre Lienhart (equal contributions, alphabetical order) 
+         from AWS GenAI Innovation Center
+
+WARNING: These kernels:
+   - Are tested only against internal nightly builds
+   - May not be compatible with public NeuronSDK releases
+   - Have not been extensively tested across all input configurations
+   - Carry no compatibility guarantees
+   - The behavior of these kernels may be modified without prior notice
+"""
+
+import math
+import numpy as np
+import torch
+from torch import nn
+import torch_xla.core.xla_model as xm
+
+from neuronxcc import nki
+import neuronxcc.nki.language as nl
+import neuronxcc.nki.typing as nt
+from neuronxcc.nki import benchmark
+
+# For debugging
+# import os
+# os.environ["NEURON_FRAMEWORK_DEBUG"] = "1"
+# os.environ["NEURON_CC_FLAGS"]= " --disable-dge "
+
+
+@nki.jit
+def interpolate_trilinear_2x_fwd(src_arr: nt.tensor, chunk_size: int = 4) -> nt.tensor:
+    """
+    This function implements a NKI kernel for trilinear 2x upscaling (interpolation) on a 5D 
+    input tensor array for the `align_corners=False` case and using advanced indexing only.
+    Source array N & C dimensions are mapped to the SBUF partition dimension. D, H & W dimensions are mapped to the 
+    SBUF free dimension. The kernel chunks the source array along the D dimension in chunks of `chunk_size` faces. 
+    From a physical memory perspective, the kernel therefore operates on source array tiles of 
+    size (pmax, chunk_size * h_src * w_src).
+
+    Args:
+        src_arr (nt.tensor): Input HBM tensor of shape (N, C, D_src, H_src, W_src).
+        chunk_size (int): Size of the chunk along the D free dimension.
+    """
+    P_TILE_SIZE = nl.tile_size.pmax # 128
+
+    n_src, c_src, d_src, h_src, w_src = src_arr.shape
+    n_dst, c_dst, d_dst, h_dst, w_dst = n_src, c_src, d_src * 2, h_src * 2, w_src * 2
+
+    assert n_src == n_dst, "Input batch and output batch sizes must be identical"
+    assert c_src == c_dst, "Input channel and output channel sizes must be identical"
+    assert d_dst == 2 * d_src, "Output depth must be twice the input depth"
+    assert h_dst == 2 * h_src, "Output height must be twice the input height"
+    assert w_dst == 2 * w_src, "Output width must be twice the input width"
+    n, c = n_src, c_src
+    
+    weight_1d = 1 / 4 # specific to scaling_factor=2.0 & align_corners=False
+
+    src_arr = src_arr.reshape((n * c, d_src, h_src, w_src))
+    dst_arr = nl.ndarray(
+        [n_dst * c_dst, d_dst, h_dst, w_dst], 
+        dtype=src_arr.dtype,
+        buffer=nl.shared_hbm
+    )
+
+    wdw_size = chunk_size
+    step_size = wdw_size - 1
+
+    for d in nl.static_range(math.ceil((d_src - wdw_size)/step_size) + 1):
+        d_start_hbm_src = max(0, d * step_size) 
+        d_end_hbm_src = min(wdw_size + d * step_size, d_src)
+        
+        d_tile_size_src = d_end_hbm_src - d_start_hbm_src
+        d_tile_size_dst = 2 * d_tile_size_src
+        
+        d_start_tile_dst = 1 if d_start_hbm_src else 0
+        d_end_tile_dst = d_tile_size_dst
+        
+        d_start_hbm_dst = 2 * d_start_hbm_src + 1 if d_start_hbm_src else 0
+        d_end_hbm_dst = 2 * d_end_hbm_src
+        for p in nl.affine_range(math.ceil(n * c / P_TILE_SIZE)):
+            out_tile = nl.ndarray([P_TILE_SIZE, d_tile_size_dst, h_dst, w_dst], dtype=src_arr.dtype, buffer=nl.sbuf)
+
+            ### Load input array from HBM
+            i_p = p * P_TILE_SIZE + nl.arange(P_TILE_SIZE)[:, None, None, None]
+            i_d = nl.arange(d_start_hbm_src, d_end_hbm_src)[None, :, None, None]
+            i_h = nl.arange(h_src)[None, None, :, None]
+            i_w = nl.arange(w_src)[None, None, None, :]
+
+            in_tile = nl.load(src_arr[i_p, i_d, i_h, i_w], mask=(i_p < n * c))
+
+            ### Core region
+            weight_3d = weight_1d ** 3
+
+            i_p = nl.arange(P_TILE_SIZE)[:, None, None, None, None, None, None]
+            i_d_dst = (2 * nl.arange(d_tile_size_src - 1)[None, None, None, None, :, None, None] + 1) + nl.arange(2)[None, :, None, None, None, None, None]
+            i_h_dst = (2 * nl.arange(h_src - 1)[None, None, None, None, None, :, None] + 1) + nl.arange(2)[None, None, :, None, None, None, None]
+            i_w_dst = (2 * nl.arange(w_src - 1)[None, None, None, None, None, None, :] + 1) + nl.arange(2)[None, None, None, :, None, None, None]
+
+            # (9*3)*weight_3d = 0.42
+            i_d_src_042 = nl.arange(d_tile_size_src - 1)[None, None, None, None, :, None, None] + nl.arange(2)[None,:, None, None, None, None, None]
+            i_h_src_042 = nl.arange(h_src - 1)[None, None, None, None, None, :, None] + nl.arange(2)[None, None, :, None, None, None, None]
+            i_w_src_042 = nl.arange(w_src - 1)[None, None, None, None, None, None, :] + nl.arange(2)[None, None, None, :, None, None, None]
+
+            # (3*3)*weight_3d (depth) = 0.14
+            i_d_src_014_d = nl.arange(d_tile_size_src - 1)[None, None, None, None, :, None, None] + (-1 * nl.arange(2)[None, :, None, None, None, None, None] + 1)
+            i_h_src_014_d = nl.arange(h_src - 1)[None, None, None, None, None, :, None] + nl.arange(2)[None, None, :, None, None, None, None]
+            i_w_src_014_d = nl.arange(w_src - 1)[None, None, None, None, None, None, :] + nl.arange(2)[None, None, None, :, None, None, None]
+
+            # (3*3)*weight_3d (height) = 0.14
+            i_d_src_014_h = nl.arange(d_tile_size_src - 1)[None, None, None, None, :, None, None] + nl.arange(2)[None, :, None, None, None, None, None]
+            i_h_src_014_h = nl.arange(h_src - 1)[None, None, None, None, None, :, None] + (-1 * nl.arange(2)[None, None, :, None, None, None, None] + 1)
+            i_w_src_014_h = nl.arange(w_src - 1)[None, None, None, None, None, None, :] + nl.arange(2)[None, None, None, :, None, None, None]
+
+            # (1*3)*weight_3d (width) = 0.05
+            i_d_src_005_w = nl.arange(d_tile_size_src - 1)[None, None, None, None, :, None, None] + (-1 * nl.arange(2)[None, :, None, None, None, None, None] + 1)
+            i_h_src_005_w = nl.arange(h_src - 1)[None, None, None, None, None, :, None] + (-1 * nl.arange(2)[None, None, :, None, None, None, None] + 1)
+            i_w_src_005_w = nl.arange(w_src - 1)[None, None, None, None, None, None, :] + nl.arange(2)[None, None, None, :, None, None, None]
+
+            # (9*1)*weight_3d (width) = 0.14
+            i_d_src_014_w = nl.arange(d_tile_size_src - 1)[None, None, None, None, :, None, None] + nl.arange(2)[None, :, None, None, None, None, None]
+            i_h_src_014_w = nl.arange(h_src - 1)[None, None, None, None, None, :, None] + nl.arange(2)[None, None, :, None, None, None, None]
+            i_w_src_014_w = nl.arange(w_src - 1)[None, None, None, None, None, None, :] + (-1 * nl.arange(2)[None, None, None, :, None, None, None] + 1)
+
+            # (3*1)*weight_3d (depth) = 0.05
+            i_d_src_005_d = nl.arange(d_tile_size_src - 1)[None, None, None, None, :, None, None] + (-1 * nl.arange(2)[None, :, None, None, None, None, None] + 1)
+            i_h_src_005_d = nl.arange(h_src - 1)[None, None, None, None, None, :, None] + nl.arange(2)[None, None, :, None, None, None, None]
+            i_w_src_005_d = nl.arange(w_src - 1)[None, None, None, None, None, None, :] + (-1 * nl.arange(2)[None, None, None, :, None, None, None] + 1)
+
+            # (3*1)*weight_3d (height) = 0.05
+            i_d_src_005_h = nl.arange(d_tile_size_src - 1)[None, None, None, None, :, None, None] + nl.arange(2)[None, :, None, None, None, None, None]
+            i_h_src_005_h = nl.arange(h_src - 1)[None, None, None, None, None, :, None] + (-1 * nl.arange(2)[None, None, :, None, None, None, None] + 1)
+            i_w_src_005_h = nl.arange(w_src - 1)[None, None, None, None, None, None, :] + (-1 * nl.arange(2)[None, None, None, :, None, None, None] + 1)
+
+            # (1*1)*weight_3d = 0.01
+            i_d_src_001 = nl.arange(d_tile_size_src - 1)[None, None, None, None, :, None, None] + (-1 * nl.arange(2)[None, :, None, None, None, None, None] + 1)
+            i_h_src_001 = nl.arange(h_src - 1)[None, None, None, None, None, :, None] + (-1 * nl.arange(2)[None, None, :, None, None, None, None] + 1)
+            i_w_src_001 = nl.arange(w_src - 1)[None, None, None, None, None, None, :] + (-1 * nl.arange(2)[None, None, None, :, None, None, None] + 1)
+            
+            out_tile[i_p, i_d_dst, i_h_dst, i_w_dst] = (
+                (9 * 3) * weight_3d * in_tile[i_p, i_d_src_042, i_h_src_042, i_w_src_042] + \
+                (3 * 3) * weight_3d * in_tile[i_p, i_d_src_014_d, i_h_src_014_d, i_w_src_014_d] + \
+                (3 * 3) * weight_3d * in_tile[i_p, i_d_src_014_h, i_h_src_014_h, i_w_src_014_h] + \
+                (1 * 3) * weight_3d * in_tile[i_p, i_d_src_005_w, i_h_src_005_w, i_w_src_005_w] + \
+                (9 * 1) * weight_3d * in_tile[i_p, i_d_src_014_w, i_h_src_014_w, i_w_src_014_w] + \
+                (3 * 1) * weight_3d * in_tile[i_p, i_d_src_005_d, i_h_src_005_d, i_w_src_005_d] + \
+                (3 * 1) * weight_3d * in_tile[i_p, i_d_src_005_h, i_h_src_005_h, i_w_src_005_h] + \
+                (1 * 1) * weight_3d * in_tile[i_p, i_d_src_001, i_h_src_001, i_w_src_001]
+            )
+        
+            ### Faces
+            weight_2d = weight_1d ** 2
+
+            i_p = nl.arange(P_TILE_SIZE)[:, None, None, None, None, None]
+            
+            ## d=0 and d=d_dst - 1 faces (borders excluded)
+            i_d_dst = ((d_tile_size_dst - 1) * nl.arange(2)[None, :, None, None, None, None])
+            i_h_dst = (2 * nl.arange(h_src - 1)[None, None, None, None, :, None] + 1) + nl.arange(2)[None, None, :, None, None, None]
+            i_w_dst = (2 * nl.arange(w_src - 1)[None, None, None, None, None, :] + 1) + nl.arange(2)[None, None, None, :, None, None]
+
+            i_d_src = ((d_tile_size_src - 1) * nl.arange(2)[None, :, None, None, None, None])
+
+            i_h_src_056 = nl.arange(h_src - 1)[None, None, None, None, :, None] + nl.arange(2)[None, None, :, None, None, None]
+            i_w_src_056 = nl.arange(w_src - 1)[None, None, None, None, None, :] + nl.arange(2)[None, None, None, :, None, None]
+
+            i_h_src_018_h = nl.arange(h_src - 1)[None, None, None, None, :, None] + (-1 * nl.arange(2)[None, None, :, None, None, None] + 1)
+            i_w_src_018_h = nl.arange(w_src - 1)[None, None, None, None, None, :] + nl.arange(2)[None, None, None, :, None, None]
+
+            i_h_src_018_w = nl.arange(h_src - 1)[None, None, None, None, :, None] + nl.arange(2)[None, None, :, None, None, None]
+            i_w_src_018_w = nl.arange(w_src - 1)[None, None, None, None, None, :] + (-1 * nl.arange(2)[None, None, None, :, None, None] + 1)
+
+            i_h_src_006 = nl.arange(h_src - 1)[None, None, None, None, :, None] + (-1 * nl.arange(2)[None, None, :, None, None, None] + 1)
+            i_w_src_006 = nl.arange(w_src - 1)[None, None, None, None, None, :] + (-1 * nl.arange(2)[None, None, None, :, None, None] + 1)
+            
+            out_tile[i_p, i_d_dst, i_h_dst, i_w_dst] = (
+                9 * weight_2d * in_tile[i_p, i_d_src, i_h_src_056, i_w_src_056] + \
+                3 * weight_2d * in_tile[i_p, i_d_src, i_h_src_018_h, i_w_src_018_h] + \
+                3 * weight_2d * in_tile[i_p, i_d_src, i_h_src_018_w, i_w_src_018_w] + \
+                1 * weight_2d * in_tile[i_p, i_d_src, i_h_src_006, i_w_src_006]
+            )
+            
+            ## h=0 and h=h_dst - 1 faces (borders excluded)
+            i_d_dst = (2 * nl.arange(d_tile_size_src - 1)[None, None, None, None, :, None] + 1) + nl.arange(2)[None, None, :, None, None, None]
+            i_h_dst = ((h_dst - 1) * nl.arange(2)[None, :, None, None, None, None])
+            i_w_dst = (2 * nl.arange(w_src - 1)[None, None, None, None, None, :] + 1) + nl.arange(2)[None, None, None, :, None, None]
+
+            i_h_src = ((h_src - 1) * nl.arange(2)[None, :, None, None, None, None])
+
+            i_d_src_056 = nl.arange(d_tile_size_src - 1)[None, None, None, None, :, None] + nl.arange(2)[None, None, :, None, None, None]
+            i_w_src_056 = nl.arange(w_src - 1)[None, None, None, None, None, :] + nl.arange(2)[None, None, None, :, None, None]
+
+            i_d_src_018_d = nl.arange(d_tile_size_src - 1)[None, None, None, None, :, None] + (-1 * nl.arange(2)[None, None, :, None, None, None] + 1)
+            i_w_src_018_d = nl.arange(w_src - 1)[None, None, None, None, None, :] + nl.arange(2)[None, None, None, :, None, None]
+
+            i_d_src_018_w = nl.arange(d_tile_size_src - 1)[None, None, None, None, :, None] + nl.arange(2)[None, None, :, None, None, None]
+            i_w_src_018_w = nl.arange(w_src - 1)[None, None, None, None, None, :] + (-1 * nl.arange(2)[None, None, None, :, None, None] + 1)
+
+            i_d_src_006 = nl.arange(d_tile_size_src - 1)[None, None, None, None, :, None] + (-1 * nl.arange(2)[None, None, :, None, None, None] + 1)
+            i_w_src_006 = nl.arange(w_src - 1)[None, None, None, None, None, :] + (-1 * nl.arange(2)[None, None, None, :, None, None] + 1)
+            
+            out_tile[i_p, i_d_dst, i_h_dst, i_w_dst] = (
+                9 * weight_2d * in_tile[i_p, i_d_src_056, i_h_src, i_w_src_056] + \
+                3 * weight_2d * in_tile[i_p, i_d_src_018_d, i_h_src, i_w_src_018_d] + \
+                3 * weight_2d * in_tile[i_p, i_d_src_018_w, i_h_src, i_w_src_018_w] + \
+                1 * weight_2d * in_tile[i_p, i_d_src_006, i_h_src, i_w_src_006]
+            )
+            
+            ## w=0 and w=w_dst - 1 faces (borders excluded)
+            i_d_dst = (2 * nl.arange(d_tile_size_src - 1)[None, None, None, None, :, None] + 1) + nl.arange(2)[None, None, :, None, None, None]
+            i_h_dst = (2 * nl.arange(h_src - 1)[None, None, None, None, None, :] + 1) + nl.arange(2)[None, None, None, :, None, None]
+            i_w_dst = ((w_dst - 1) * nl.arange(2)[None, :, None, None, None, None])
+
+            i_w_src = ((w_src - 1) * nl.arange(2)[None, :, None, None, None, None])
+
+            i_d_src_056 = nl.arange(d_tile_size_src - 1)[None, None, None, None, :, None] + nl.arange(2)[None, None, :, None, None, None]
+            i_h_src_056 = nl.arange(h_src - 1)[None, None, None, None, None, :] + nl.arange(2)[None, None, None, :, None, None]
+
+            i_d_src_018_d = nl.arange(d_tile_size_src - 1)[None, None, None, None, :, None] + (-1 * nl.arange(2)[None, None, :, None, None, None] + 1)
+            i_h_src_018_d = nl.arange(h_src - 1)[None, None, None, None, None, :] + nl.arange(2)[None, None, None, :, None, None]
+
+            i_d_src_018_h = nl.arange(d_tile_size_src - 1)[None, None, None, None, :, None] + nl.arange(2)[None, None, :, None, None, None]
+            i_h_src_018_h = nl.arange(h_src - 1)[None, None, None, None, None, :] + (-1 * nl.arange(2)[None, None, None, :, None, None] + 1)
+
+            i_d_src_006 = nl.arange(d_tile_size_src - 1)[None, None, None, None, :, None] + (-1 * nl.arange(2)[None, None, :, None, None, None] + 1)
+            i_h_src_006 = nl.arange(h_src - 1)[None, None, None, None, None, :] + (-1 * nl.arange(2)[None, None, None, :, None, None] + 1)
+            
+            out_tile[i_p, i_d_dst, i_h_dst, i_w_dst] = (
+                9 * weight_2d * in_tile[i_p, i_d_src_056, i_h_src_056, i_w_src] + \
+                3 * weight_2d * in_tile[i_p, i_d_src_018_d, i_h_src_018_d, i_w_src] + \
+                3 * weight_2d * in_tile[i_p, i_d_src_018_h, i_h_src_018_h, i_w_src] + \
+                1 * weight_2d * in_tile[i_p, i_d_src_006, i_h_src_006, i_w_src]
+            )
+        
+            ### Edges
+            i_p = nl.arange(P_TILE_SIZE)[:, None, None, None, None]
+
+            ## (d=0 and d=d_dst - 1) x (h=0 and h=h_dst - 1) edges (corners excluded)
+            i_d_dst = ((d_tile_size_dst - 1) * nl.arange(2)[None, :, None, None, None])
+            i_h_dst = ((h_dst - 1) * nl.arange(2)[None, None, :, None, None])
+            i_w_dst = (2 * nl.arange(w_src - 1)[None, None, None, None, :] + 1) + nl.arange(2)[None, None, None, :, None]
+
+            i_d_src = ((d_tile_size_src - 1) * nl.arange(2)[None, :, None, None, None])
+            i_h_src = ((h_src - 1) * nl.arange(2)[None, None, :, None, None])
+
+            i_w_src_075 = nl.arange(w_src - 1)[None, None, None, None, :] + nl.arange(2)[None, None, None, :, None]
+            i_w_src_025 = nl.arange(w_src - 1)[None, None, None, None, :] + (-1 * nl.arange(2)[None, None, None, :, None] + 1)
+            
+            out_tile[i_p, i_d_dst, i_h_dst, i_w_dst] = (
+                3 * weight_1d * in_tile[i_p, i_d_src, i_h_src, i_w_src_075] + \
+                1 * weight_1d * in_tile[i_p, i_d_src, i_h_src, i_w_src_025]
+            )
+            
+            ## (d=0 and d=d_dst - 1) x (w=0 and w=w_dst - 1) edges (corners excluded)
+            i_d_dst = ((d_tile_size_dst - 1) * nl.arange(2)[None, :, None, None, None])
+            i_h_dst = (2 * nl.arange(h_src - 1)[None, None, None, None, :] + 1) + nl.arange(2)[None, None, None, :, None]
+            i_w_dst = ((w_dst - 1) * nl.arange(2)[None, None, :, None, None])
+
+            i_d_src = ((d_tile_size_src - 1) * nl.arange(2)[None, :, None, None, None])
+            i_w_src = ((w_src - 1) * nl.arange(2)[None, None, :, None, None])
+
+            i_h_src_075 = nl.arange(h_src - 1)[None, None, None, None, :] + nl.arange(2)[None, None, None, :, None]
+            i_h_src_025 = nl.arange(h_src - 1)[None, None, None, None, :] + (-1 * nl.arange(2)[None, None, None, :, None] + 1)
+            
+            out_tile[i_p, i_d_dst, i_h_dst, i_w_dst] = (
+                3 * weight_1d * in_tile[i_p, i_d_src, i_h_src_075, i_w_src] + \
+                1 * weight_1d * in_tile[i_p, i_d_src, i_h_src_025, i_w_src]
+            )
+            
+            ## (h=0 and h=h_dst - 1) x (w=0 and w=w_dst - 1) edges (corners excluded)
+            i_d_dst = (2 * nl.arange(d_tile_size_src - 1)[None, None, None, None, :] + 1) + nl.arange(2)[None, None, None, :, None]
+            i_h_dst = ((h_dst - 1) * nl.arange(2)[None, :, None, None, None])
+            i_w_dst = ((w_dst - 1) * nl.arange(2)[None, None, :, None, None])
+
+            i_h_src = ((h_src - 1) * nl.arange(2)[None, :, None, None, None])
+            i_w_src = ((w_src - 1) * nl.arange(2)[None, None, :, None, None])
+
+            i_d_src_075 = nl.arange(d_tile_size_src - 1)[None, None, None, None, :] + nl.arange(2)[None, None, None, :, None]
+            i_d_src_025 = nl.arange(d_tile_size_src - 1)[None, None, None, None, :] + (-1 * nl.arange(2)[None, None, None, :, None] + 1)
+            
+            out_tile[i_p, i_d_dst, i_h_dst, i_w_dst] = (
+                3 * weight_1d * in_tile[i_p, i_d_src_075, i_h_src, i_w_src] + \
+                1 * weight_1d * in_tile[i_p, i_d_src_025, i_h_src, i_w_src]
+            )
+        
+            #### Corners
+            i_p = nl.arange(P_TILE_SIZE)[:, None, None, None]
+
+            i_d_dst = ((d_tile_size_dst - 1) * nl.arange(2)[None, :, None, None])
+            i_h_dst = ((h_dst - 1) * nl.arange(2)[None, None, :, None])
+            i_w_dst = ((w_dst - 1) * nl.arange(2)[None, None, None, :])
+
+            i_d_src = ((d_tile_size_src - 1) * nl.arange(2)[None, :, None, None])
+            i_h_src = ((h_src - 1) * nl.arange(2)[None, None, :, None])
+            i_w_src = ((w_src - 1) * nl.arange(2)[None, None, None, :])
+            
+            out_tile[i_p, i_d_dst, i_h_dst, i_w_dst] = in_tile[i_p, i_d_src, i_h_src, i_w_src]
+
+            ### Write output array to HBM
+            i_p_tile = nl.arange(P_TILE_SIZE)[:, None, None, None]
+            i_d_tile = nl.arange(d_start_tile_dst, d_end_tile_dst)[None, :, None, None]
+            i_p_hbm = p * P_TILE_SIZE + nl.arange(P_TILE_SIZE)[:, None, None, None]
+            i_d_hbm = nl.arange(d_start_hbm_dst, d_end_hbm_dst)[None, :, None, None]
+            i_h = nl.arange(h_dst)[None, None, :, None]
+            i_w = nl.arange(w_dst)[None, None, None, :]
+
+            nl.store(dst_arr[i_p_hbm, i_d_hbm, i_h, i_w], value=out_tile[i_p_tile, i_d_tile, i_h, i_w], mask=(i_p_hbm < n * c))
+    
+    dst_arr = dst_arr.reshape((n, c, d_dst, h_dst, w_dst))
+    return dst_arr
+
+
+def check_correct():
+    print("\nChecking Correctness")
+    N, C, D, W, H = 2, 64, 23, 23, 23
+    src_arr = np.random.random_sample([N, C, D, W, H]).astype(np.float32)
+
+    baremetal_func = nki.baremetal()(interpolate_trilinear_2x_fwd)
+    dst_arr = baremetal_func(src_arr)
+    src_arr = torch.from_numpy(src_arr)
+    nki_dst_arr = torch.from_numpy(dst_arr)
+    torch_dst_arr = torch.nn.functional.interpolate(src_arr, scale_factor=2, mode="trilinear")
+    print("Is close: ", torch.allclose(nki_dst_arr, torch_dst_arr, atol=1e-4, rtol=1e-2))
+
+
+def benchmark_kernel():
+    print("\nBenchmarking")
+    N, C, D, W, H = 2, 64, 23, 23, 23
+    src_arr = np.random.random_sample([N, C, D, W, H]).astype(np.float32)
+
+    benchmark_kernel = benchmark(warmup=10, iters=100, save_neff_name='file.neff', save_trace_name='profile.ntff')(interpolate_trilinear_2x_fwd)
+    _ = benchmark_kernel(src_arr)
+    metrics = benchmark_kernel.benchmark_result.nc_latency
+    print("Latency (P50): " + str(metrics.get_latency_percentile(50)))
+    print("Latency (P99): " + str(metrics.get_latency_percentile(99)))
+
+
+def main():
+    check_correct()
+    benchmark_kernel()
+
+if __name__ == "__main__":
+    main()
+

--- a/contributed/interpolate_trilinear_fwd.py
+++ b/contributed/interpolate_trilinear_fwd.py
@@ -89,52 +89,52 @@ def interpolate_trilinear_2x_fwd(src_arr: nt.tensor, chunk_size: int = 4) -> nt.
 
             ### Core region
             weight_3d = weight_1d ** 3
-            i_p, i_dx, i_hx, i_wx, i_dy, i_hy, i_wy = nl.mgrid[
+            i_p, i_d_x, i_h_x, i_w_x, i_d_y, i_h_y, i_w_y = nl.mgrid[
                 0:P_TILE_SIZE, 0:2, 0:2, 0:2, 0:(d_tile_size_src-1), 0:(h_src-1), 0:(w_src-1)
             ]
-            i_d_dst = (2 * i_dy + 1) + i_dx
-            i_h_dst = (2 * i_hy + 1) + i_hx
-            i_w_dst = (2 * i_wy + 1) + i_wx
+            i_d_dst = (2 * i_d_y + 1) + i_d_x
+            i_h_dst = (2 * i_h_y + 1) + i_h_x
+            i_w_dst = (2 * i_w_y + 1) + i_w_x
             
             # (9*3)*weight_3d = 0.42
-            i_d_src_042 = i_dy + i_dx
-            i_h_src_042 = i_hy + i_hx
-            i_w_src_042 = i_wy + i_wx
+            i_d_src_042 = i_d_y + i_d_x
+            i_h_src_042 = i_h_y + i_h_x
+            i_w_src_042 = i_w_y + i_w_x
             
             # (3*3)*weight_3d (depth) = 0.14
-            i_d_src_014_d = i_dy + (-1 * i_dx + 1)
-            i_h_src_014_d = i_hy + i_hx
-            i_w_src_014_d = i_wy + i_wx
+            i_d_src_014_d = i_d_y + (-1 * i_d_x + 1)
+            i_h_src_014_d = i_h_y + i_h_x
+            i_w_src_014_d = i_w_y + i_w_x
             
             # (3*3)*weight_3d (height) = 0.14
-            i_d_src_014_h = i_dy + i_dx
-            i_h_src_014_h = i_hy + (-1 * i_hx + 1)
-            i_w_src_014_h = i_wy + i_wx
+            i_d_src_014_h = i_d_y + i_d_x
+            i_h_src_014_h = i_h_y + (-1 * i_h_x + 1)
+            i_w_src_014_h = i_w_y + i_w_x
             
             # (1*3)*weight_3d (width) = 0.05
-            i_d_src_005_w = i_dy + (-1 * i_dx + 1)
-            i_h_src_005_w = i_hy + (-1 * i_hx + 1)
-            i_w_src_005_w = i_wy + i_wx
+            i_d_src_005_w = i_d_y + (-1 * i_d_x + 1)
+            i_h_src_005_w = i_h_y + (-1 * i_h_x + 1)
+            i_w_src_005_w = i_w_y + i_w_x
             
             # (9*1)*weight_3d (width) = 0.14
-            i_d_src_014_w = i_dy + i_dx
-            i_h_src_014_w = i_hy + i_hx
-            i_w_src_014_w = i_wy + (-1 * i_wx + 1)
+            i_d_src_014_w = i_d_y + i_d_x
+            i_h_src_014_w = i_h_y + i_h_x
+            i_w_src_014_w = i_w_y + (-1 * i_w_x + 1)
             
             # (3*1)*weight_3d (depth) = 0.05
-            i_d_src_005_d = i_dy + (-1 * i_dx + 1)
-            i_h_src_005_d = i_hy + i_hx
-            i_w_src_005_d = i_wy + (-1 * i_wx + 1)
+            i_d_src_005_d = i_d_y + (-1 * i_d_x + 1)
+            i_h_src_005_d = i_h_y + i_h_x
+            i_w_src_005_d = i_w_y + (-1 * i_w_x + 1)
             
             # (3*1)*weight_3d (height) = 0.05
-            i_d_src_005_h = i_dy + i_dx
-            i_h_src_005_h = i_hy + (-1 * i_hx + 1)
-            i_w_src_005_h = i_wy + (-1 * i_wx + 1)
+            i_d_src_005_h = i_d_y + i_d_x
+            i_h_src_005_h = i_h_y + (-1 * i_h_x + 1)
+            i_w_src_005_h = i_w_y + (-1 * i_w_x + 1)
             
             # (1*1)*weight_3d = 0.01
-            i_d_src_001 = i_dy + (-1 * i_dx + 1)
-            i_h_src_001 = i_hy + (-1 * i_hx + 1)
-            i_w_src_001 = i_wy + (-1 * i_wx + 1)
+            i_d_src_001 = i_d_y + (-1 * i_d_x + 1)
+            i_h_src_001 = i_h_y + (-1 * i_h_x + 1)
+            i_w_src_001 = i_w_y + (-1 * i_w_x + 1)
             
             out_tile[i_p, i_d_dst, i_h_dst, i_w_dst] = (
                 (9 * 3) * weight_3d * in_tile[i_p, i_d_src_042, i_h_src_042, i_w_src_042] + \
@@ -151,20 +151,20 @@ def interpolate_trilinear_2x_fwd(src_arr: nt.tensor, chunk_size: int = 4) -> nt.
             weight_2d = weight_1d ** 2
             
             ## d=0 and d=d_dst - 1 faces (borders excluded)
-            i_p, i_d, i_hx, i_wx, i_hy, i_wy = nl.mgrid[0:P_TILE_SIZE, 0:2, 0:2, 0:2, 0:(h_src-1), 0:(w_src-1)]
+            i_p, i_d, i_h_x, i_w_x, i_h_y, i_w_y = nl.mgrid[0:P_TILE_SIZE, 0:2, 0:2, 0:2, 0:(h_src-1), 0:(w_src-1)]
             i_d_dst = ((d_tile_size_dst - 1) * i_d)
-            i_h_dst = (2 * i_hy + 1) + i_hx
-            i_w_dst = (2 * i_wy + 1) + i_wx
+            i_h_dst = (2 * i_h_y + 1) + i_h_x
+            i_w_dst = (2 * i_w_y + 1) + i_w_x
             
             i_d_src = ((d_tile_size_src - 1) * i_d)
-            i_h_src_056 = i_hy + i_hx
-            i_w_src_056 = i_wy + i_wx
-            i_h_src_018_h = i_hy + (-1 * i_hx + 1)
-            i_w_src_018_h = i_wy + i_wx
-            i_h_src_018_w = i_hy + i_hx
-            i_w_src_018_w = i_wy + (-1 * i_wx + 1)
-            i_h_src_006 = i_hy + (-1 * i_hx + 1)
-            i_w_src_006 = i_wy + (-1 * i_wx + 1)
+            i_h_src_056 = i_h_y + i_h_x
+            i_w_src_056 = i_w_y + i_w_x
+            i_h_src_018_h = i_h_y + (-1 * i_h_x + 1)
+            i_w_src_018_h = i_w_y + i_w_x
+            i_h_src_018_w = i_h_y + i_h_x
+            i_w_src_018_w = i_w_y + (-1 * i_w_x + 1)
+            i_h_src_006 = i_h_y + (-1 * i_h_x + 1)
+            i_w_src_006 = i_w_y + (-1 * i_w_x + 1)
             
             out_tile[i_p, i_d_dst, i_h_dst, i_w_dst] = (
                 9 * weight_2d * in_tile[i_p, i_d_src, i_h_src_056, i_w_src_056] + \
@@ -174,20 +174,20 @@ def interpolate_trilinear_2x_fwd(src_arr: nt.tensor, chunk_size: int = 4) -> nt.
             )
             
             ## h=0 and h=h_dst - 1 faces (borders excluded)
-            i_p, i_dx, i_h, i_wx, i_dy, i_wy = nl.mgrid[0:P_TILE_SIZE, 0:2, 0:2, 0:2, 0:(d_tile_size_src-1), 0:(w_src-1)]
-            i_d_dst = (2 * i_dy + 1) + i_dx
+            i_p, i_d_x, i_h, i_w_x, i_d_y, i_w_y = nl.mgrid[0:P_TILE_SIZE, 0:2, 0:2, 0:2, 0:(d_tile_size_src-1), 0:(w_src-1)]
+            i_d_dst = (2 * i_d_y + 1) + i_d_x
             i_h_dst = ((h_dst - 1) * i_h)
-            i_w_dst = (2 * i_wy + 1) + i_wx
+            i_w_dst = (2 * i_w_y + 1) + i_w_x
             
             i_h_src = ((h_src - 1) * i_h)
-            i_d_src_056 = i_dy + i_dx
-            i_w_src_056 = i_wy + i_wx
-            i_d_src_018_d = i_dy + (-1 * i_dx + 1)
-            i_w_src_018_d = i_wy + i_wx
-            i_d_src_018_w = i_dy + i_dx
-            i_w_src_018_w = i_wy + (-1 * i_wx + 1)
-            i_d_src_006 = i_dy + (-1 * i_dx + 1)
-            i_w_src_006 = i_wy + (-1 * i_wx + 1)
+            i_d_src_056 = i_d_y + i_d_x
+            i_w_src_056 = i_w_y + i_w_x
+            i_d_src_018_d = i_d_y + (-1 * i_d_x + 1)
+            i_w_src_018_d = i_w_y + i_w_x
+            i_d_src_018_w = i_d_y + i_d_x
+            i_w_src_018_w = i_w_y + (-1 * i_w_x + 1)
+            i_d_src_006 = i_d_y + (-1 * i_d_x + 1)
+            i_w_src_006 = i_w_y + (-1 * i_w_x + 1)
             
             out_tile[i_p, i_d_dst, i_h_dst, i_w_dst] = (
                 9 * weight_2d * in_tile[i_p, i_d_src_056, i_h_src, i_w_src_056] + \
@@ -197,20 +197,20 @@ def interpolate_trilinear_2x_fwd(src_arr: nt.tensor, chunk_size: int = 4) -> nt.
             )
             
             ## w=0 and w=w_dst - 1 faces (borders excluded)
-            i_p, i_dx, i_hx, i_w, i_dy, i_hy = nl.mgrid[0:P_TILE_SIZE, 0:2, 0:2, 0:2, 0:(d_tile_size_src-1), 0:(h_src-1)]
-            i_d_dst = (2 * i_dy + 1) + i_dx
-            i_h_dst = (2 * i_hy + 1) + i_hx
+            i_p, i_d_x, i_h_x, i_w, i_d_y, i_h_y = nl.mgrid[0:P_TILE_SIZE, 0:2, 0:2, 0:2, 0:(d_tile_size_src-1), 0:(h_src-1)]
+            i_d_dst = (2 * i_d_y + 1) + i_d_x
+            i_h_dst = (2 * i_h_y + 1) + i_h_x
             i_w_dst = ((w_dst - 1) * i_w)
             
             i_w_src = ((w_src - 1) * i_w)
-            i_d_src_056 = i_dy + i_dx
-            i_h_src_056 = i_hy + i_hx
-            i_d_src_018_d = i_dy + (-1 * i_dx + 1)
-            i_h_src_018_d = i_hy + i_hx
-            i_d_src_018_h = i_dy + i_dx
-            i_h_src_018_h = i_hy + (-1 * i_hx + 1)
-            i_d_src_006 = i_dy + (-1 * i_dx + 1)
-            i_h_src_006 = i_hy + (-1 * i_hx + 1)
+            i_d_src_056 = i_d_y + i_d_x
+            i_h_src_056 = i_h_y + i_h_x
+            i_d_src_018_d = i_d_y + (-1 * i_d_x + 1)
+            i_h_src_018_d = i_h_y + i_h_x
+            i_d_src_018_h = i_d_y + i_d_x
+            i_h_src_018_h = i_h_y + (-1 * i_h_x + 1)
+            i_d_src_006 = i_d_y + (-1 * i_d_x + 1)
+            i_h_src_006 = i_h_y + (-1 * i_h_x + 1)
             
             out_tile[i_p, i_d_dst, i_h_dst, i_w_dst] = (
                 9 * weight_2d * in_tile[i_p, i_d_src_056, i_h_src_056, i_w_src] + \
@@ -221,15 +221,15 @@ def interpolate_trilinear_2x_fwd(src_arr: nt.tensor, chunk_size: int = 4) -> nt.
             
             ### Edges
             ## (d=0 and d=d_dst - 1) x (h=0 and h=h_dst - 1) edges (corners excluded)
-            i_p, i_d, i_h, i_wx, i_wy = nl.mgrid[0:P_TILE_SIZE, 0:2, 0:2, 0:2, 0:(w_src-1)]
+            i_p, i_d, i_h, i_w_x, i_w_y = nl.mgrid[0:P_TILE_SIZE, 0:2, 0:2, 0:2, 0:(w_src-1)]
             i_d_dst = ((d_tile_size_dst - 1) * i_d)
             i_h_dst = ((h_dst - 1) * i_h)
-            i_w_dst = (2 * i_wy + 1) + i_wx
+            i_w_dst = (2 * i_w_y + 1) + i_w_x
             
             i_d_src = ((d_tile_size_src - 1) * i_d)
             i_h_src = ((h_src - 1) * i_h)
-            i_w_src_075 = i_wy + i_wx
-            i_w_src_025 = i_wy + (-1 * i_wx + 1)
+            i_w_src_075 = i_w_y + i_w_x
+            i_w_src_025 = i_w_y + (-1 * i_w_x + 1)
             
             out_tile[i_p, i_d_dst, i_h_dst, i_w_dst] = (
                 3 * weight_1d * in_tile[i_p, i_d_src, i_h_src, i_w_src_075] + \
@@ -237,15 +237,15 @@ def interpolate_trilinear_2x_fwd(src_arr: nt.tensor, chunk_size: int = 4) -> nt.
             )
             
             ## (d=0 and d=d_dst - 1) x (w=0 and w=w_dst - 1) edges (corners excluded)
-            i_p, i_d, i_hx, i_w, i_hy = nl.mgrid[0:P_TILE_SIZE, 0:2, 0:2, 0:2, 0:(h_src-1)]
+            i_p, i_d, i_h_x, i_w, i_h_y = nl.mgrid[0:P_TILE_SIZE, 0:2, 0:2, 0:2, 0:(h_src-1)]
             i_d_dst = ((d_tile_size_dst - 1) * i_d)
-            i_h_dst = (2 * i_hy + 1) + i_hx
+            i_h_dst = (2 * i_h_y + 1) + i_h_x
             i_w_dst = ((w_dst - 1) * i_w)
             
             i_d_src = ((d_tile_size_src - 1) * i_d)
             i_w_src = ((w_src - 1) * i_w)
-            i_h_src_075 = i_hy + i_hx
-            i_h_src_025 = i_hy + (-1 * i_hx + 1)
+            i_h_src_075 = i_h_y + i_h_x
+            i_h_src_025 = i_h_y + (-1 * i_h_x + 1)
             
             out_tile[i_p, i_d_dst, i_h_dst, i_w_dst] = (
                 3 * weight_1d * in_tile[i_p, i_d_src, i_h_src_075, i_w_src] + \
@@ -253,15 +253,15 @@ def interpolate_trilinear_2x_fwd(src_arr: nt.tensor, chunk_size: int = 4) -> nt.
             )
             
             ## (h=0 and h=h_dst - 1) x (w=0 and w=w_dst - 1) edges (corners excluded)
-            i_p, i_dx, i_h, i_w, i_dy = nl.mgrid[0:P_TILE_SIZE, 0:2, 0:2, 0:2, 0:(d_tile_size_src-1)]
-            i_d_dst = (2 * i_dy + 1) + i_dx
+            i_p, i_d_x, i_h, i_w, i_d_y = nl.mgrid[0:P_TILE_SIZE, 0:2, 0:2, 0:2, 0:(d_tile_size_src-1)]
+            i_d_dst = (2 * i_d_y + 1) + i_d_x
             i_h_dst = ((h_dst - 1) * i_h)
             i_w_dst = ((w_dst - 1) * i_w)
             
             i_h_src = ((h_src - 1) * i_h)
             i_w_src = ((w_src - 1) * i_w)
-            i_d_src_075 = i_dy + i_dx
-            i_d_src_025 = i_dy + (-1 * i_dx + 1)
+            i_d_src_075 = i_d_y + i_d_x
+            i_d_src_025 = i_d_y + (-1 * i_d_x + 1)
             
             out_tile[i_p, i_d_dst, i_h_dst, i_w_dst] = (
                 3 * weight_1d * in_tile[i_p, i_d_src_075, i_h_src, i_w_src] + \


### PR DESCRIPTION
This PR adds nki kernel samples for bilinear and trilinear interpolations. As title mentions, these kernels only support upsampling to 2x dimensions with align_corners=False. 

In collaboration with @plienhar.

### Testing:

Please see detailed unit test requirements in the [CONTRIBUTING.md](https://github.com/aws-neuron/nki-samples/blob/main/CONTRIBUTING.md)

- [x] The change is covered by numeric check using `nki.baremetal`
- [x] The change is covered by performance benchmark test using `nki.benchmark`
- [ ] The change is covered by end-to-end integration test

### Pull Request Checklist

- [x] I have filled in all the required field in the template
- [x] I have tested locally that all the tests pass
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.

