### PR TITLE
matmul sbuf allocation dimension fix

### DIFF
--- a/src/nki_samples/tutorials/matrix_multiplication/matrix_multiplication_nki_kernels.py
+++ b/src/nki_samples/tutorials/matrix_multiplication/matrix_multiplication_nki_kernels.py
@@ -13,7 +13,7 @@ import numpy as np
 
 
 # NKI_EXAMPLE_16_BEGIN
-@nki.jit
+git @nki.jit
 def nki_matmul_basic_(lhsT, rhs):
   """NKI kernel to compute a 64x128x512 matrix multiplication operation
 
@@ -151,7 +151,7 @@ def nki_matmul_hoist_load_(lhsT, rhs):
   for m in nl.affine_range(M // TILE_M):
     # Load a whole column tiles from lhsT (with K * TILE_N numbers)
     # This corresponds to the whole row in the original lhs
-    lhsT_tiles = nl.ndarray((K // TILE_K, nl.par_dim(TILE_K), TILE_N),
+    lhsT_tiles = nl.ndarray((K // TILE_K, nl.par_dim(TILE_K), TILE_M),
                             dtype=lhsT.dtype,
                             buffer=nl.sbuf)
 

--- a/src/nki_samples/tutorials/matrix_multiplication/matrix_multiplication_nki_kernels.py
+++ b/src/nki_samples/tutorials/matrix_multiplication/matrix_multiplication_nki_kernels.py
@@ -13,7 +13,7 @@ import numpy as np
 
 
 # NKI_EXAMPLE_16_BEGIN
-git @nki.jit
+@nki.jit
 def nki_matmul_basic_(lhsT, rhs):
   """NKI kernel to compute a 64x128x512 matrix multiplication operation
 


### PR DESCRIPTION
### Issue #, if available:

Small fix to allocate the correct size of tensor in Sbuf

### Description of changes:
self explanatory 

### Testing:

Please see detailed unit test requirements in the [CONTRIBUTING.md](https://github.com/aws-neuron/nki-samples/blob/main/CONTRIBUTING.md)

- [ ] The change is covered by numeric check using `nki.baremetal`
- [ ] The change is covered by performance benchmark test using `nki.benchmark`
- [ ] The change is covered by end-to-end integration test

### Pull Request Checklist

- [ ] I have filled in all the required field in the template
- [ ] I have tested locally that all the tests pass
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.

