### PR TITLE
NKI flash paged attention kernel on variable-length input sequences

### DIFF
--- a/contributed/neuron-team-kernels/flash_paged_attn_varlen/README.md
+++ b/contributed/neuron-team-kernels/flash_paged_attn_varlen/README.md
@@ -54,3 +54,9 @@ We also support parallel testing using multiple Neuron Cores with `pytest-xdist`
 nworker=8
 TEST_EXEC_MODE=$mode pytest test_kernel.py -xv -n$nworker
 ```
+
+
+### Branch hint
+On-chip control flow benefit from branch hint. One can use env variable
+`ENABLE_BRANCH_HINT=1` to enable branch hint. However, this might trigger
+compiler bugs on Trn2 and kernel might hang and time out.

--- a/contributed/neuron-team-kernels/flash_paged_attn_varlen/constants.py
+++ b/contributed/neuron-team-kernels/flash_paged_attn_varlen/constants.py
@@ -19,4 +19,5 @@ import neuronxcc.nki.language as nl
 B_P_SIZE = nl.tile_size.pmax
 B_FMAX_SIZE = nl.tile_size.gemm_moving_fmax
 
-NEG_INF = -9984.0  # Magic number to replace -inf similar to what Tensorizer uses
+# Magic number to replace -inf similar to what Tensorizer uses
+NEG_INF = -9984.0

--- a/contributed/neuron-team-kernels/flash_paged_attn_varlen/flash_attn_impl.py
+++ b/contributed/neuron-team-kernels/flash_paged_attn_varlen/flash_attn_impl.py
@@ -23,6 +23,7 @@ from neuronxcc.nki.typing import scalar
 
 from constants import NEG_INF, B_P_SIZE, B_FMAX_SIZE
 from paged_cache import (
+    prepare_kv_block_dim_tiling,
     transform_block_tables_for_indirect_load,
     load_k_tile_from_cache,
     load_v_tile_from_cache,
@@ -35,8 +36,6 @@ from flash_attn_core import (
 from utils import (
     ceil_div,
     pad_to_multiple,
-    is_power_of_2,
-    round_down_to_power_of_2,
     load_indices,
     load_indices_for_loop_step,
     transform_to_vector_dge_layout,
@@ -58,81 +57,6 @@ def load_v_tile(v_hbm_tile, cur_v_tile, large_tile_idx, v_i, LARGE_TILE_SZ):
     )
 
 
-def check_input_shapes(
-    query,
-    key,
-    value,
-    key_cache,
-    value_cache,
-    tile_masks,
-    active_mask,
-    decode_mode,
-):
-    if decode_mode:
-        INNER_KV_TILE_SIZE, _, N_INNER_KV_TILE = tile_masks.shape
-        LARGE_Q_TILE_SIZE = 1
-        assert INNER_KV_TILE_SIZE == B_P_SIZE
-        LARGE_KV_TILE_SIZE = INNER_KV_TILE_SIZE * N_INNER_KV_TILE
-    else:
-        _, LARGE_Q_TILE_SIZE, LARGE_KV_TILE_SIZE = tile_masks.shape
-    b, h, seqlen_q, d = query.shape
-    assert seqlen_q <= 8192, f"Large {seqlen_q=} consumes too much sbuf space"
-    if seqlen_q <= B_P_SIZE:
-        assert is_power_of_2(seqlen_q), f"{seqlen_q=} is expected to be power of 2"
-    elif seqlen_q <= B_FMAX_SIZE:
-        assert seqlen_q % B_P_SIZE == 0, f"{seqlen_q=} must be mulitple of {B_P_SIZE=}"
-    else:
-        assert (
-            seqlen_q % B_FMAX_SIZE == 0
-        ), f"{seqlen_q=} must be multiple of {B_FMAX_SIZE=}"
-    assert (
-        seqlen_q % LARGE_Q_TILE_SIZE == 0
-    ), f"{seqlen_q=} must be multiple of {LARGE_Q_TILE_SIZE=}"
-    assert b == 1, f"Batch size must be 1 for Ragged Tensor, got {b}"
-    assert (
-        d >= 16 and d <= 128 and is_power_of_2(d)
-    ), f" we head_dim must be power of 2 in range [16, 128], got head dim {d}"
-    num_blocks, k_h, block_size, _ = key_cache.shape
-    assert tuple(key_cache.shape) == (
-        num_blocks,
-        k_h,
-        block_size,
-        d,
-    ), f"{key_cache.shape=} mismatch!"
-    assert tuple(value_cache.shape) == (
-        num_blocks,
-        k_h,
-        block_size,
-        d,
-    ), f"{value_cache.shape=} mismatch!"
-    assert key is None or tuple(key.shape) == (
-        1,
-        k_h,
-        d,
-        seqlen_q,
-    ), f"key shape {key.shape} mismatch!"
-    assert value is None or tuple(value.shape) == (
-        1,
-        k_h,
-        seqlen_q,
-        d,
-    ), f"value shape {value.shape} mismatch!"
-    assert tile_masks.dtype == nl.uint8, f"{tile_masks.dtype=} is expected to be uint8"
-    assert (
-        active_mask.dtype == nl.uint8
-    ), f"{active_mask.dtype=} is expected to be uint8"
-
-    return (
-        b,
-        h,
-        k_h,
-        seqlen_q,
-        d,
-        LARGE_Q_TILE_SIZE,
-        LARGE_KV_TILE_SIZE,
-    )
-
-
 def allocate_prefill_accum_buffers(
     seqlen_q,
     INNER_Q_TILE_SIZE,
@@ -148,16 +72,26 @@ def allocate_prefill_accum_buffers(
     )
 
     for i in nl.affine_range(ceil_div(seqlen_q, INNER_Q_TILE_SIZE)):
-        i_x, i_y, i_z = nl.mgrid[:INNER_Q_TILE_SIZE, :q_h_per_k_h, : B_D_SIZE + 1]
+        i_x, i_y, i_z = nl.mgrid[
+            :INNER_Q_TILE_SIZE, :q_h_per_k_h, : B_D_SIZE + 1
+        ]
         i_x = i_x + i * INNER_Q_TILE_SIZE
-        nl.store(dst=olm_buffer[i_x, i_y, i_z], value=0.0, mask=(i_x < seqlen_q))
+        nl.store(
+            dst=olm_buffer[i_x, i_y, i_z],
+            value=0.0,
+            mask=(i_x < seqlen_q),
+        )
         i_x, i_y, i_z = nl.mgrid[
             :INNER_Q_TILE_SIZE,
             :q_h_per_k_h,
             B_D_SIZE + 1 : B_D_SIZE + 2,
         ]
         i_x = i_x + i * INNER_Q_TILE_SIZE
-        nl.store(dst=olm_buffer[i_x, i_y, i_z], value=NEG_INF, mask=(i_x < seqlen_q))
+        nl.store(
+            dst=olm_buffer[i_x, i_y, i_z],
+            value=NEG_INF,
+            mask=(i_x < seqlen_q),
+        )
 
     # =============== Global Flash Attention accumulators END ================== #
     return (olm_buffer,)
@@ -176,11 +110,6 @@ def prefill_context_tokens(
     kernel_dtype,
     acc_type,
     loop_unroll_factor,
-    n_small_in_large_q_tile,
-    INNER_Q_TILE_SIZE,
-    num_blocks_per_large_tile,
-    block_size,
-    block_size_tiling_factor,
     batch_id,
     head_id,
     k_h,
@@ -189,6 +118,16 @@ def prefill_context_tokens(
     B_F_SIZE,
     B_D_SIZE,
 ):
+    (
+        INNER_Q_TILE_SIZE,
+        MAX_NUM_TILE,
+        n_small_in_large_q_tile,
+        LARGE_KV_TILE_SIZE,
+    ) = tile_masks.shape
+    key_cache, value_cache, block_size_tiling_factor, block_size = (
+        prepare_kv_block_dim_tiling(key_cache, value_cache, LARGE_KV_TILE_SIZE)
+    )
+    num_blocks_per_large_tile = LARGE_KV_TILE_SIZE // block_size
     olm_next_tile_sbuf = nl.zeros(
         (
             par_dim(INNER_Q_TILE_SIZE),
@@ -205,14 +144,15 @@ def prefill_context_tokens(
     )
     # prepare block tables
     tile_block_tables_sbuf = load_indices(tile_block_tables)
-    tile_block_tables_transformed_sbuf = transform_block_tables_for_indirect_load(
-        tile_block_tables_sbuf,
-        block_size_tiling_factor=block_size_tiling_factor,
-        num_head=k_h,
-        head_id=head_id,
-        identity_for_transpose=None,
+    tile_block_tables_transformed_sbuf = (
+        transform_block_tables_for_indirect_load(
+            tile_block_tables_sbuf,
+            block_size_tiling_factor=block_size_tiling_factor,
+            num_head=k_h,
+            head_id=head_id,
+            identity_for_transpose=None,
+        )
     )
-    MAX_NUM_TILE = tile_block_tables.shape[0]
     num_loads = tile_block_tables_transformed_sbuf.shape[1]
     MAX_NUM_LOOP = MAX_NUM_TILE // loop_unroll_factor
     tile_block_tables_transformed_hbm = nl.ndarray(
@@ -228,42 +168,31 @@ def prefill_context_tokens(
             ],
         )
 
-    cond_dtype = np.int32
-    cond = nl.ndarray((1, 1), buffer=nl.hbm, dtype=cond_dtype)
-    loop_index = nl.zeros((1, 1), dtype=np.int32)
-    cond_var = True
+    block_tables_sbuf = nl.ndarray(
+        tile_block_tables_transformed_hbm.shape[1:],
+        dtype=tile_block_tables_transformed_hbm.dtype,
+    )
+    block_tables_sbuf[...] = nl.load(tile_block_tables_transformed_hbm[0])
+
     num_dynamic_loop_steps_sbuf = nl.load(num_dynamic_loop_steps)
     assert num_dynamic_loop_steps_sbuf.shape == (1, 1)
     if loop_unroll_factor > 1:
         num_unrolled_iota = nisa.iota(
-            nl.arange(loop_unroll_factor)[None, :],
-            dtype=nl.uint32,
+            nl.arange(loop_unroll_factor)[None, :], dtype=nl.uint32
         )
     else:
         num_unrolled_iota = None
 
-    num_loads = num_blocks_per_large_tile // B_P_SIZE
+    MAX_NUM_BUFFER_ALLOWED = 2
+    MULTI_BUFFER = min(MAX_NUM_BUFFER_ALLOWED, loop_unroll_factor)
+    assert loop_unroll_factor % MULTI_BUFFER == 0
     # XXX: Work around a DMA skipping correctness issue:
     #      If nl.ndarray is used to allocate buffer for DMA skipping,
     #      kernel does not produce correct results.
-    if nisa.get_nc_version() == nisa.nc_version.gen2:
-        PER_BUFFER_SPACE = num_loads * block_size * B_D_SIZE * key_cache.itemsize * 2
-        MAX_NUM_BUFFER_ALLOWED = round_down_to_power_of_2(
-            192 * 1024 // PER_BUFFER_SPACE
-        )
-        assert MAX_NUM_BUFFER_ALLOWED >= 1, f"Not enough sbuf space"
-        # XXX: disable prefill double buffering on Trn1 to reduce failure and avoid hanging
-        MAX_NUM_BUFFER_ALLOWED = 1
-    else:
-        # XXX: double buffering on Trn2 has 1% failed tests
-        MAX_NUM_BUFFER_ALLOWED = 2
-    MULTI_BUFFER = min(MAX_NUM_BUFFER_ALLOWED, loop_unroll_factor)
-    assert loop_unroll_factor % MULTI_BUFFER == 0
-    # XXX: nl.zeros due to DMA skipping, otherwise, may get NaNs
     q_load_buffer = nl.zeros(
         (
             par_dim(INNER_Q_TILE_SIZE),
-            loop_unroll_factor,
+            MULTI_BUFFER,
             n_small_in_large_q_tile,
             q_h_per_k_h,
             B_D_SIZE,
@@ -271,19 +200,15 @@ def prefill_context_tokens(
         dtype=kernel_dtype,
         buffer=nl.sbuf,
     )
-    k_load_buffer = nl.zeros(
+    num_loads = num_blocks_per_large_tile // B_P_SIZE
+    k_load_buffer = nl.ndarray(
         (par_dim(B_P_SIZE), MULTI_BUFFER, num_loads, block_size * B_D_SIZE),
         dtype=key_cache.dtype,
     )
-    v_load_buffer = nl.zeros(
+    v_load_buffer = nl.ndarray(
         (par_dim(B_P_SIZE), MULTI_BUFFER, num_loads * block_size * B_D_SIZE),
         dtype=value_cache.dtype,
     )
-    MAX_NUM_TILE, LARGE_Q_TILE_SIZE, LARGE_KV_TILE_SIZE = tile_masks.shape
-    tile_masks = tile_masks.reshape(
-        (MAX_NUM_TILE * LARGE_Q_TILE_SIZE, LARGE_KV_TILE_SIZE)
-    )
-
     olm_unrolled_sbuf = nl.ndarray(
         (
             par_dim(INNER_Q_TILE_SIZE),
@@ -294,37 +219,63 @@ def prefill_context_tokens(
         ),
         dtype=acc_type,
     )
-    while scalar(cond_var):
-        tile_q_indices_sbuf = prepare_q_indices_range(
-            tile_q_indices,
-            loop_index,
-            loop_unroll_factor,
+    tile_masks = tile_masks.reshape(
+        (
             INNER_Q_TILE_SIZE,
-            identity_for_transpose=None,
-            num_tiles_iota=num_unrolled_iota,
+            MAX_NUM_TILE // loop_unroll_factor,
+            loop_unroll_factor,
+            n_small_in_large_q_tile,
+            LARGE_KV_TILE_SIZE,
         )
+    )
+    mask_buffer = nl.ndarray(
+        (
+            par_dim(INNER_Q_TILE_SIZE),
+            MULTI_BUFFER,
+            n_small_in_large_q_tile,
+            LARGE_KV_TILE_SIZE,
+        ),
+        dtype=tile_masks.dtype,
+    )
+    tile_q_indices_sbuf = nl.ndarray(
+        (
+            par_dim(INNER_Q_TILE_SIZE),
+            n_small_in_large_q_tile,
+            loop_unroll_factor,
+        ),
+        dtype=tile_q_indices.dtype,
+    )
+    loop_index = nl.zeros((1, 1), dtype=np.int32)
+    prepare_q_indices_range(
+        tile_q_indices,
+        loop_index,
+        loop_unroll_factor,
+        INNER_Q_TILE_SIZE,
+        tile_q_indices_sbuf,
+        identity_for_transpose=None,
+        num_tiles_iota=num_unrolled_iota,
+    )
+    mask_buffer[:, 0, :, :] = nl.load(tile_masks[:, 0, 0, :, :])
+    q_update_pred_sbuf = nl.ndarray((loop_unroll_factor, 1), dtype=nl.uint8)
+    q_update_pred_sbuf[...] = nl.load(q_update_pred[0])
+    load_k_tile_from_cache(
+        key_cache=key_cache,
+        block_tables=block_tables_sbuf,
+        large_k_tile_idx=0,
+        num_blocks_per_large_tile=num_blocks_per_large_tile,
+        block_size=block_size,
+        B_D_SIZE=B_D_SIZE,
+        k_load_buffer=k_load_buffer,
+    )
+    for _ in range(scalar(num_dynamic_loop_steps_sbuf)):
         olm_unrolled_sbuf[:, nl.ds(1, loop_unroll_factor)] = 0
         olm_unrolled_sbuf[:, :, :, :, B_D_SIZE + 1] = NEG_INF
         olm_unrolled_sbuf[:, 0] = nl.copy(olm_next_tile_sbuf)
-        block_tables_sbuf = nl.load(
-            tile_block_tables_transformed_hbm[loop_index[0, 0]],
-            # mode=oob_mode.skip,
-        )
-        cur_masks = load_indices_for_loop_step(
-            tile_masks,
-            loop_index,
-            LARGE_Q_TILE_SIZE * loop_unroll_factor,
-            partition_size=INNER_Q_TILE_SIZE,
-        )
-        # q_indices = nl.load(tile_q_indices_transformed_hbm[loop_index[0, 0]])  #, mode=oob_mode.skip)
-        # cur_masks = nl.load(tile_masks[loop_index[0, 0]])
-        q_update_pred_sbuf = nl.ndarray((loop_unroll_factor, 1), dtype=nl.uint8)
-        q_update_pred_sbuf[...] = nl.load(q_update_pred[loop_index[0, 0]])
         q_update_pred_broadcast = transpose_broadcast_q_pred(
-            q_update_pred_sbuf,
-            INNER_Q_TILE_SIZE,
+            q_update_pred_sbuf, INNER_Q_TILE_SIZE
         )
         prefill_prior(
+            loop_index=loop_index,
             num_tiles_unrolled=loop_unroll_factor,
             query=query,
             key_cache=key_cache,
@@ -332,11 +283,12 @@ def prefill_context_tokens(
             q_load_buffer=q_load_buffer,
             k_load_buffer=k_load_buffer,
             v_load_buffer=v_load_buffer,
+            mask_buffer=mask_buffer,
             olm_buffer_hbm=olm_buffer,
             olm_unrolled_sbuf=olm_unrolled_sbuf,
             tile_q_indices_sbuf=tile_q_indices_sbuf,
             block_tables_sbuf=block_tables_sbuf,
-            cur_masks=cur_masks,
+            tile_masks=tile_masks,
             q_update_pred_broadcast=q_update_pred_broadcast,
             num_blocks_per_large_tile=num_blocks_per_large_tile,
             block_size=block_size,
@@ -352,18 +304,42 @@ def prefill_context_tokens(
             B_F_SIZE=B_F_SIZE,
             B_D_SIZE=B_D_SIZE,
         )
-        olm_next_tile_sbuf[...] = nl.copy(olm_unrolled_sbuf[:, loop_unroll_factor])
         # update loop_index
         loop_index[...] = nl.add(loop_index[...], 1)
-        # update conditions
-        cond_next = nisa.tensor_tensor(
-            loop_index,
-            num_dynamic_loop_steps_sbuf,
-            nl.less,
-            dtype=nl.int32,
+        block_tables_sbuf[...] = nl.load(
+            tile_block_tables_transformed_hbm[loop_index[0, 0]],
+            mode=oob_mode.skip,
         )
-        nl.store(dst=cond, value=cond_next)
-        cond_var = cond
+        prepare_q_indices_range(
+            tile_q_indices,
+            loop_index,
+            loop_unroll_factor,
+            INNER_Q_TILE_SIZE,
+            tile_q_indices_sbuf,
+            identity_for_transpose=None,
+            num_tiles_iota=num_unrolled_iota,
+        )
+        olm_next_tile_sbuf[...] = nl.copy(
+            olm_unrolled_sbuf[:, loop_unroll_factor]
+        )
+
+        mask_buffer[:, 0, :, :] = nl.load(
+            tile_masks[:, loop_index[0, 0], 0, :, :],
+            mode=oob_mode.skip,
+        )
+        q_update_pred_sbuf[...] = nl.load(
+            q_update_pred[loop_index[0, 0]],
+            mode=oob_mode.skip,
+        )
+        load_k_tile_from_cache(
+            key_cache=key_cache,
+            block_tables=block_tables_sbuf,
+            large_k_tile_idx=0,
+            num_blocks_per_large_tile=num_blocks_per_large_tile,
+            block_size=block_size,
+            B_D_SIZE=B_D_SIZE,
+            k_load_buffer=k_load_buffer,
+        )
 
 
 def prepare_q_indices_range(
@@ -371,6 +347,7 @@ def prepare_q_indices_range(
     loop_index,
     num_tiles_per_step,
     INNER_Q_TILE_SIZE,
+    tile_q_indices_sbuf,
     identity_for_transpose,
     num_tiles_iota,
 ):
@@ -387,15 +364,7 @@ def prepare_q_indices_range(
     assert INNER_Q_TILE_SIZE <= B_P_SIZE
     index_partition_size = min(num_indices_per_tile, INNER_Q_TILE_SIZE)
     num_index_partitions = ceil_div(num_indices_per_tile, index_partition_size)
-    transposed_q_indices = nl.ndarray(
-        (
-            par_dim(index_partition_size),
-            num_index_partitions,
-            num_tile_partitions * tile_partition_size,
-        ),
-        dtype=tile_q_indices.dtype,
-    )
-    transposed_q_indices_reshape = transposed_q_indices.reshape(
+    transposed_q_indices_reshape = tile_q_indices_sbuf.reshape(
         (
             index_partition_size,
             num_index_partitions,
@@ -410,10 +379,10 @@ def prepare_q_indices_range(
             index_partition_size,
             identity_for_transpose=identity_for_transpose,
         )
-    return transposed_q_indices
 
 
 def prefill_prior(
+    loop_index,
     num_tiles_unrolled,
     query,
     key_cache,
@@ -421,11 +390,12 @@ def prefill_prior(
     q_load_buffer,
     k_load_buffer,
     v_load_buffer,
+    mask_buffer,
     olm_buffer_hbm,
     olm_unrolled_sbuf,
     tile_q_indices_sbuf,
     block_tables_sbuf,
-    cur_masks,
+    tile_masks,
     q_update_pred_broadcast,
     num_blocks_per_large_tile,
     block_size,
@@ -442,11 +412,12 @@ def prefill_prior(
     B_D_SIZE,
 ):
     """
-    Handles `num_tiles_unrolled` tiles of attention between Q and context tokens by having a static
-    sequential loop over the tiles.
+    Handles `num_tiles_unrolled` tiles of attention between Q and context
+    tokens by having a static sequential loop over the tiles.
 
     This function is also used as loop body of dynamic-loop kernel
     """
+    MULTI_BUFFER = k_load_buffer.shape[1]
     identity_k, identity_p = identity_store.get(
         (kernel_dtype, B_P_SIZE),
         (kernel_dtype, INNER_Q_TILE_SIZE),
@@ -455,7 +426,7 @@ def prefill_prior(
     q_sbuf_tile_transposed = nl.ndarray(
         (
             par_dim(B_D_SIZE),
-            num_tiles_unrolled,
+            MULTI_BUFFER,
             q_h_per_k_h,
             n_small_in_large_q_tile,
             INNER_Q_TILE_SIZE,
@@ -463,20 +434,10 @@ def prefill_prior(
         dtype=query.dtype,
         buffer=nl.sbuf,
     )
-    MULTI_BUFFER = k_load_buffer.shape[1]
-    LARGE_KV_TILE_SIZE = cur_masks.shape[-1]
+    LARGE_KV_TILE_SIZE = tile_masks.shape[-1]
     transposed_k_tile = nl.ndarray(
         (par_dim(B_D_SIZE), MULTI_BUFFER, LARGE_KV_TILE_SIZE),
         dtype=kernel_dtype,
-    )
-    load_k_tile_from_cache(
-        key_cache=key_cache,
-        block_tables=block_tables_sbuf,
-        large_k_tile_idx=0,
-        num_blocks_per_large_tile=num_blocks_per_large_tile,
-        block_size=block_size,
-        B_D_SIZE=B_D_SIZE,
-        k_load_buffer=k_load_buffer,
     )
     transpose_k_cache_tile(
         k_load_buffer=k_load_buffer,
@@ -494,7 +455,9 @@ def prefill_prior(
             for i_q_h in nl.affine_range(q_h_per_k_h):
                 i_p = nl.arange(INNER_Q_TILE_SIZE)[:, None]
                 i_f = nl.arange(B_D_SIZE)[None, :]
-                q_load_buffer[i_p, local_tile_idx, small_q_idx, i_q_h, i_f] = nl.load(
+                q_load_buffer[
+                    i_p, local_tile_idx % MULTI_BUFFER, small_q_idx, i_q_h, i_f
+                ] = nl.load(
                     query[
                         batch_id,
                         head_id * q_h_per_k_h + i_q_h,
@@ -511,17 +474,19 @@ def prefill_prior(
                     buffer=nl.psum,
                 )
                 PF_transpose_with_PE(
-                    q_load_buffer[:, local_tile_idx, small_q_idx, i_q_h, :],
+                    q_load_buffer[
+                        :, local_tile_idx % MULTI_BUFFER, small_q_idx, i_q_h, :
+                    ],
                     q_t_psum,
                     identity_for_transpose=identity_p,
                     out_in_psum=True,
                 )
-                q_sbuf_tile_transposed[:, local_tile_idx, i_q_h, small_q_idx, :] = (
-                    nl.multiply(
-                        q_t_psum,
-                        softmax_scale,
-                        dtype=kernel_dtype,
-                    )
+                q_sbuf_tile_transposed[
+                    :, local_tile_idx % MULTI_BUFFER, i_q_h, small_q_idx, :
+                ] = nl.multiply(
+                    q_t_psum,
+                    softmax_scale,
+                    dtype=kernel_dtype,
                 )
         cur_v_tile = load_v_tile_from_cache(
             value_cache=value_cache,
@@ -533,7 +498,8 @@ def prefill_prior(
             kernel_dtype=kernel_dtype,
             v_load_buffer=v_load_buffer,
         )
-        if local_tile_idx + 1 < num_tiles_unrolled:
+
+        def prefetch_and_transpose_k():
             load_k_tile_from_cache(
                 key_cache=key_cache,
                 block_tables=block_tables_sbuf,
@@ -543,32 +509,10 @@ def prefill_prior(
                 B_D_SIZE=B_D_SIZE,
                 k_load_buffer=k_load_buffer,
             )
-
-        # perform compute
-        for small_q_idx in nl.affine_range(n_small_in_large_q_tile):
-            for i_q_h in nl.affine_range(q_h_per_k_h):
-                q_tile = q_sbuf_tile_transposed[:, local_tile_idx, i_q_h, small_q_idx]
-
-                _flash_attention_core(
-                    q_local_tile=q_tile,
-                    k=transposed_k_tile[:, local_tile_idx % MULTI_BUFFER],
-                    v=cur_v_tile,
-                    olm_buffer=olm_unrolled_sbuf[:, local_tile_idx, small_q_idx, i_q_h],
-                    kernel_dtype=kernel_dtype,
-                    acc_type=acc_type,
-                    tile_mask=cur_masks[
-                        :,
-                        local_tile_idx * n_small_in_large_q_tile + small_q_idx,
-                    ],
-                    use_causal_mask=False,
-                    q_tile_idx=None,
-                    Q_TILE_SIZE=INNER_Q_TILE_SIZE,
-                    LARGE_KV_TILE_SIZE=LARGE_KV_TILE_SIZE,
-                    B_F_SIZE=B_F_SIZE,
-                    B_D_SIZE=B_D_SIZE,
-                )
-        # start transpose next k
-        if local_tile_idx + 1 < num_tiles_unrolled:
+            mask_buffer[:, (local_tile_idx + 1) % MULTI_BUFFER, :, :] = nl.load(
+                tile_masks[:, loop_index[0, 0], local_tile_idx + 1, :, :]
+            )
+            # start transpose next k
             transpose_k_cache_tile(
                 k_load_buffer=k_load_buffer,
                 transposed_k_tile=transposed_k_tile,
@@ -579,12 +523,46 @@ def prefill_prior(
                 kernel_dtype=kernel_dtype,
                 identity_for_transpose=identity_k,
             )
+
+        if MULTI_BUFFER > 1 and local_tile_idx + 1 < num_tiles_unrolled:
+            prefetch_and_transpose_k()
+
+        # perform compute
+        for small_q_idx in nl.affine_range(n_small_in_large_q_tile):
+            for i_q_h in nl.affine_range(q_h_per_k_h):
+                q_tile = q_sbuf_tile_transposed[
+                    :, local_tile_idx % MULTI_BUFFER, i_q_h, small_q_idx
+                ]
+
+                _flash_attention_core(
+                    q_local_tile=q_tile,
+                    k=transposed_k_tile[:, local_tile_idx % MULTI_BUFFER],
+                    v=cur_v_tile,
+                    olm_buffer=olm_unrolled_sbuf[
+                        :, local_tile_idx, small_q_idx, i_q_h
+                    ],
+                    kernel_dtype=kernel_dtype,
+                    acc_type=acc_type,
+                    tile_mask=mask_buffer[
+                        :, local_tile_idx % MULTI_BUFFER, small_q_idx
+                    ],
+                    use_causal_mask=False,
+                    q_tile_idx=None,
+                    Q_TILE_SIZE=INNER_Q_TILE_SIZE,
+                    LARGE_KV_TILE_SIZE=LARGE_KV_TILE_SIZE,
+                    B_F_SIZE=B_F_SIZE,
+                    B_D_SIZE=B_D_SIZE,
+                )
         nisa.tensor_copy_predicated(
             src=olm_unrolled_sbuf[:, local_tile_idx],
             dst=olm_unrolled_sbuf[:, local_tile_idx + 1],
             predicate=q_update_pred_broadcast[:, local_tile_idx],
         )
 
+        if MULTI_BUFFER == 1 and local_tile_idx + 1 < num_tiles_unrolled:
+            prefetch_and_transpose_k()
+
+    for local_tile_idx in nl.affine_range(num_tiles_unrolled):
         # write out aggregation buffer
         for small_q_idx in nl.affine_range(n_small_in_large_q_tile):
             i_p = nl.arange(INNER_Q_TILE_SIZE)[:, None, None]
@@ -596,7 +574,9 @@ def prefill_prior(
                     i_f_h,
                     i_f_d,
                 ],
-                olm_unrolled_sbuf[i_p, local_tile_idx, small_q_idx, i_f_h, i_f_d],
+                olm_unrolled_sbuf[
+                    i_p, local_tile_idx, small_q_idx, i_f_h, i_f_d
+                ],
                 mode=oob_mode.skip,
             )
 
@@ -625,7 +605,12 @@ def active_and_epilogue(
     assert seqlen_q % ACTIVE_Q_TILE_SIZE == 0
 
     olm_buffer_sbuf = nl.ndarray(
-        (par_dim(ACTIVE_Q_TILE_SIZE), num_active_tiles, q_h_per_k_h, B_D_SIZE + 2),
+        (
+            par_dim(ACTIVE_Q_TILE_SIZE),
+            num_active_tiles,
+            q_h_per_k_h,
+            B_D_SIZE + 2,
+        ),
         dtype=acc_type,
     )
 
@@ -683,7 +668,10 @@ def active_and_epilogue(
                     dtype=query.dtype,
                 )
                 q_sbuf_tile[:, :] = nl.load(
-                    q_hbm_tile[nl.ds(i * ACTIVE_Q_TILE_SIZE, ACTIVE_Q_TILE_SIZE), :],
+                    q_hbm_tile[
+                        nl.ds(i * ACTIVE_Q_TILE_SIZE, ACTIVE_Q_TILE_SIZE),
+                        :,
+                    ],
                 )  # load (d, 128) tile in SBUF
                 q_tile_scaled = nl.ndarray(
                     (ACTIVE_Q_TILE_SIZE, B_D_SIZE),
@@ -694,7 +682,10 @@ def active_and_epilogue(
                     softmax_scale,
                     dtype=kernel_dtype,
                 )
-                q_tile = nl.ndarray((B_D_SIZE, ACTIVE_Q_TILE_SIZE), dtype=kernel_dtype)
+                q_tile = nl.ndarray(
+                    (B_D_SIZE, ACTIVE_Q_TILE_SIZE),
+                    dtype=kernel_dtype,
+                )
                 PF_transpose_with_PE(
                     q_tile_scaled,
                     q_tile,
@@ -775,7 +766,9 @@ def load_and_broadcast_q_update_preds(q_update_pred, loop_index, B_D_SIZE):
         dtype=nl.uint8,
     )
     if nisa.get_nc_version() == nisa.nc_version.gen3:
-        out_broadcast = nl.broadcast_to(out, shape=(B_D_SIZE, padded_free_dim_size))
+        out_broadcast = nl.broadcast_to(
+            out, shape=(B_D_SIZE, padded_free_dim_size)
+        )
     else:
         out_broadcast = nl.ndarray(
             (par_dim(B_D_SIZE), padded_free_dim_size),
@@ -783,7 +776,9 @@ def load_and_broadcast_q_update_preds(q_update_pred, loop_index, B_D_SIZE):
         )
         tile_size = min(B_F_SIZE, free_dim_size)
         num_tiles = padded_free_dim_size // tile_size
-        out_broadcast_reshape = out_broadcast.reshape((B_D_SIZE, num_tiles, tile_size))
+        out_broadcast_reshape = out_broadcast.reshape(
+            (B_D_SIZE, num_tiles, tile_size)
+        )
         for i in nl.affine_range(num_tiles):
             broadcast_partition_with_PE(
                 src=out[:, nl.ds(i * tile_size, tile_size)],
@@ -861,9 +856,6 @@ def decode_context_tokens(
     kernel_dtype,
     acc_type,
     loop_unroll_factor,
-    num_blocks_per_large_tile,
-    block_size,
-    block_size_tiling_factor,
     batch_id,
     head_id,
     k_h,
@@ -871,14 +863,22 @@ def decode_context_tokens(
     softmax_scale,
     B_D_SIZE,
 ):
+    INNER_KV_TILE_SIZE, _, N_INNER_KV_TILE = tile_masks.shape
+    LARGE_KV_TILE_SIZE = INNER_KV_TILE_SIZE * N_INNER_KV_TILE
+    key_cache, value_cache, block_size_tiling_factor, block_size = (
+        prepare_kv_block_dim_tiling(key_cache, value_cache, LARGE_KV_TILE_SIZE)
+    )
+    num_blocks_per_large_tile = LARGE_KV_TILE_SIZE // block_size
     # prepare block tables
     tile_block_tables_sbuf = load_indices(tile_block_tables)
-    tile_block_tables_transformed_sbuf = transform_block_tables_for_indirect_load(
-        tile_block_tables_sbuf,
-        block_size_tiling_factor=block_size_tiling_factor,
-        num_head=k_h,
-        head_id=head_id,
-        identity_for_transpose=None,
+    tile_block_tables_transformed_sbuf = (
+        transform_block_tables_for_indirect_load(
+            tile_block_tables_sbuf,
+            block_size_tiling_factor=block_size_tiling_factor,
+            num_head=k_h,
+            head_id=head_id,
+            identity_for_transpose=None,
+        )
     )
     MAX_NUM_TILE = tile_block_tables.shape[0]
     num_loads = tile_block_tables_transformed_sbuf.shape[1]
@@ -939,14 +939,11 @@ def decode_context_tokens(
     )
     tile_mask_sbuf[...] = nl.load(tile_masks[:, 0, :, :])
 
-    cond_dtype = np.int32
-    cond = nl.ndarray((1, 1), buffer=nl.hbm, dtype=cond_dtype)
-    loop_index = nl.zeros((1, 1), dtype=np.int32)
-    cond_var = True
     num_dynamic_loop_steps_sbuf = nl.load(num_dynamic_loop_steps)
     assert num_dynamic_loop_steps_sbuf.shape == (1, 1)
     olm_buffer_reshaped = olm_buffer.reshape(
-        (MAX_NUM_TILE // loop_unroll_factor, loop_unroll_factor) + olm_buffer.shape[1:]
+        (MAX_NUM_TILE // loop_unroll_factor, loop_unroll_factor)
+        + olm_buffer.shape[1:]
     )
 
     (identity_o, identity_q) = identity_store.get(
@@ -969,15 +966,7 @@ def decode_context_tokens(
         kernel_dtype=kernel_dtype,
         identity_for_transpose=identity_q,
     )
-    if nisa.get_nc_version() == nisa.nc_version.gen2:
-        PER_BUFFER_SPACE = num_loads * block_size * B_D_SIZE * key_cache.itemsize * 2
-        MAX_NUM_BUFFER_ALLOWED = round_down_to_power_of_2(
-            192 * 1024 // PER_BUFFER_SPACE
-        )
-        assert MAX_NUM_BUFFER_ALLOWED >= 1, f"Not enough sbuf space"
-    else:
-        # Trn2 only needs 2 buffer, having more slows down performance
-        MAX_NUM_BUFFER_ALLOWED = 2
+    MAX_NUM_BUFFER_ALLOWED = 2
     MULTI_BUFFER = min(MAX_NUM_BUFFER_ALLOWED, loop_unroll_factor)
     assert loop_unroll_factor % MULTI_BUFFER == 0
 
@@ -996,7 +985,8 @@ def decode_context_tokens(
     identity_for_transpose_lm = nl.ones((1, 1), dtype=acc_type)
     # load all q and multiply scale
 
-    while scalar(cond_var):
+    loop_index = nl.zeros((1, 1), dtype=np.int32)
+    for _ in range(scalar(num_dynamic_loop_steps_sbuf)):
         q_update_pred_broadcast = transpose_broadcast_q_pred(
             q_update_pred_sbuf, B_D_SIZE
         )
@@ -1041,23 +1031,17 @@ def decode_context_tokens(
             identity_store=identity_store,
         )
 
-        # update conditions
-        cond_next = nisa.tensor_tensor(
-            loop_index,
-            num_dynamic_loop_steps_sbuf,
-            nl.less,
-            dtype=nl.int32,
+        q_indices[...] = nl.load(
+            tile_q_indices[loop_index[0, 0]],
+            mode=oob_mode.skip,
         )
-        nl.store(dst=cond, value=cond_next)
-        cond_var = cond
-
-        q_indices[...] = nl.load(tile_q_indices[loop_index[0, 0]], mode=oob_mode.skip)
         q_update_pred_sbuf[...] = nl.load(
             q_update_pred[loop_index[0, 0]],
             mode=oob_mode.skip,
         )
         block_tables_sbuf[...] = nl.load(
-            tile_block_tables_transformed_hbm[loop_index[0, 0]], mode=oob_mode.skip
+            tile_block_tables_transformed_hbm[loop_index[0, 0]],
+            mode=oob_mode.skip,
         )
         i_p = nl.arange(B_P_SIZE)[:, None, None]
         i_q = nl.arange(loop_unroll_factor)[None, :, None]
@@ -1084,7 +1068,11 @@ def decode_context_tokens(
                 out_in_psum=True,
             )
             olm_sbuf[:, i_q_h, nl.ds(0, B_D_SIZE)] = nl.copy(o_tmp)
-            l_tmp = nl.ndarray((loop_unroll_factor, 1), dtype=acc_type, buffer=nl.psum)
+            l_tmp = nl.ndarray(
+                (loop_unroll_factor, 1),
+                dtype=acc_type,
+                buffer=nl.psum,
+            )
             PF_transpose_with_PE(
                 src=l_buffer_sbuf[:, nl.ds(0, loop_unroll_factor), i_q_h],
                 out=l_tmp,
@@ -1092,7 +1080,11 @@ def decode_context_tokens(
                 out_in_psum=True,
             )
             olm_sbuf[:, i_q_h, nl.ds(B_D_SIZE, 1)] = nl.copy(l_tmp)
-            m_tmp = nl.ndarray((loop_unroll_factor, 1), dtype=acc_type, buffer=nl.psum)
+            m_tmp = nl.ndarray(
+                (loop_unroll_factor, 1),
+                dtype=acc_type,
+                buffer=nl.psum,
+            )
             PF_transpose_with_PE(
                 src=m_buffer_sbuf[:, nl.ds(0, loop_unroll_factor), i_q_h],
                 out=m_tmp,
@@ -1188,8 +1180,8 @@ def decode_prior(
     identity_store,
 ):
     """
-    Handles `num_tiles_unrolled` tiles of attention between Q and context tokens by having a static
-    sequential loop over the tiles.
+    Handles `num_tiles_unrolled` tiles of attention between Q and context tokens
+    by having a static sequential loop over the tiles.
 
     This function is also used as loop body of dynamic-loop kernel
     """
@@ -1238,7 +1230,9 @@ def decode_prior(
             identity_for_transpose_m_step2=identity_m_step2,
         )
 
-    olm_next_tile_sbuf[:, 0, :] = nl.copy(o_buffer_sbuf[:, num_tiles_unrolled, :])
+    olm_next_tile_sbuf[:, 0, :] = nl.copy(
+        o_buffer_sbuf[:, num_tiles_unrolled, :]
+    )
     olm_next_tile_sbuf[nl.ds(0, 1), 1, :] = nl.copy(
         l_buffer_sbuf[:, num_tiles_unrolled, :]
     )

--- a/contributed/neuron-team-kernels/flash_paged_attn_varlen/test_kernel.py
+++ b/contributed/neuron-team-kernels/flash_paged_attn_varlen/test_kernel.py
@@ -149,8 +149,8 @@ def _run_test(
         (128, 2048, 16),  # 128 blocks
         (128, 4096, 32),  # 128 blocks
         (256, 2048, 256),  # 8 blocks
-        (256, 4096, 32),  # 128 blocks
         (256, 1024, 4),  # 256 blocks
+        (128, 8192, 32),  # 256 blocks
     ],
 )
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Description of changes:
We developed a NKI kernel for performing paged attention on a batch of sequences with variable lengths. The kernel takes ragged Query, Key, Value, and block KV context cache as input. We adopt a block-sparse design, by concatenating sequences in the batch and using fixed-shape tiles to iteratively handle attention QK score region that has real computation and to skip padded areas.

### Overall design
This kernel handles both prefill requests and decode requests. It has three phases as shown in figure below:
1. Dynamic loop over prefill requests' context token tiles (Red box)
2. Dynamic loop over decode requests' context token tiles (Blue box)
3. [Optional] Handle all new prompt tokens (vanilla self-attention). This can be skipped if KVs of new tokens have already been updated into paged KV cache.
<img width="3909" height="1902" alt="varlen_attn" src="https://github.com/user-attachments/assets/24dfcb79-2109-4424-a50a-4560ccb3c6d2" />

The code contains 2 main components:
- [On CPU] `execution_planner.py`: Tile planner that generates an execution plan based on sequence lengths in the batch
- [On Neuron Device] `varlen_attention_kernel.py`: NKI kernel that performs flash-attention style computation following the tile plan

### Code structure
Kernel implementation:
1. `varlen_attention_kernel.py`: varlen kernel entry point, overall kernel skeleton
2. `execution_planner.py`: CPU execution planner that generates tile plan based on input sequence lengths, implemented in numpy
3. `flash_attn_impl.py`: implementation of prefill and decode sub-component and tile plan execution logic using dynamic control flow
4. `flash_attn_core.py`: logic to incrementally perform flash attention on a single tile. For prefill, it's the same and simplified logic as flash attention [example](https://github.com/aws-neuron/nki-samples/blob/main/src/nki_samples/reference/attention.py#L85). For decode, it implements kq matmul and cascaded reduction tailored to Neuron device

Runner: `kernel_runner.py` a wrapper class that accepts batch's sequence lengths and generates tile plan, then calls NKI kernel to execute.

Testing code: `test_kernel.py`

### Supported Neuron device
- [x] Trn1
- [x] Trn2 with LNC=1
- [ ] Trn2 with LNC=2 will be supported later via context or data parallel

### Testing:
- [x] The change is covered by numeric check using `nki.baremetal`
- [x] The change is covered by performance benchmark test using `nki.benchmark` (will upstream later)
- [ ] The change is covered by end-to-end integration test

### Pull Request Checklist
- [x] I have filled in all the required field in the template
- [x] I have tested locally that all the tests pass
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.

