### PR TITLE
feat: add opt-in DMA transpose for TRN2

### DIFF
--- a/src/nki_samples/reference/attention.py
+++ b/src/nki_samples/reference/attention.py
@@ -14,6 +14,7 @@ from neuronxcc.nki.language import par_dim
 from dataclasses import dataclass
 from functools import reduce as functools_reduce
 from operator import mul as operator_mul
+from nki_samples.utils.flags import use_dma_transpose_default
 
 
 def n_elts(shape):
@@ -42,7 +43,14 @@ class FlashConfig:
 
 
 @nki.jit(mode='trace')
-def transpose_p_local(p_local_transposed, p_local, LARGE_TILE_SZ, use_dma_transpose=False):
+def transpose_p_local(p_local_transposed, p_local, LARGE_TILE_SZ, use_dma_transpose=None):
+  """
+  Transpose helper for flash attention.
+  """
+  # read env default if caller didn't override
+  if use_dma_transpose is None:
+    use_dma_transpose = use_dma_transpose_default()
+    
   for i in nl.affine_range(LARGE_TILE_SZ // 512):
     # Temporarily disable use_dma_tranpose by default until we stablized it
     if use_dma_transpose and nisa.get_nc_version() >= nisa.nc_version.gen3:

--- a/src/nki_samples/utils/__init__.py
+++ b/src/nki_samples/utils/__init__.py
@@ -1,0 +1,3 @@
+"""
+Utility modules for NKI kernels.
+"""

--- a/src/nki_samples/utils/flags.py
+++ b/src/nki_samples/utils/flags.py
@@ -1,0 +1,38 @@
+"""
+Environment flag utilities for NKI kernels.
+"""
+import os
+
+_TRUE_VALUES = {"1", "true", "yes", "on"}
+_FALSE_VALUES = {"0", "false", "no", "off", ""}
+
+def env_flag(name: str, default: bool = False) -> bool:
+    """
+    Parse an environment variable as a boolean flag.
+    
+    Args:
+        name: Environment variable name
+        default: Default value if env var is not set
+        
+    Returns:
+        True if env var is set to a truthy value, False otherwise
+    """
+    value = os.getenv(name)
+    if value is None:
+        return default
+    v = value.strip().lower()
+    if v in _TRUE_VALUES:
+        return True
+    if v in _FALSE_VALUES:
+        return False
+    return default  # fallback for unexpected strings
+
+def use_dma_transpose_default() -> bool:
+    """
+    Global default for enabling DMA-based transpose on TRN2.
+    Opt-in, disabled by default.
+    
+    Returns:
+        True if NKI_USE_DMA_TRANSPOSE environment variable is set to a truthy value
+    """
+    return env_flag("NKI_USE_DMA_TRANSPOSE", False)


### PR DESCRIPTION
### Issue #, if available:

Closes #82 

### Description of changes:
Hello! In this PR I added support for a global environment variable `NKI_USE_DMA_TRANSPOSE` in `transpose_p_local` (attention.py). If `use_dma_transpose` is explicitly passed then that takes priority.  And if it is `None` the env var acts as the default. This makes it easier to enable DMA-based transpose globally without modifying multiple call sites :)

### Testing:

**Notes:** I don't have access to Neuron devices locally. I added pure Python unit tests locally for the env flag logic and ran it under (`test/unit/test_dma_flag_logic.py`) and verified import/use of the helper in `attention.py`. I’m leaving the hardware tests to the project CI and maintainers since this PR only adds a configuration default and keeps existing behaviour unchanged unless the flag is explicitly enabled.

- [ ] The change is covered by numeric check using `nki.baremetal`
- [ ] The change is covered by performance benchmark test using `nki.benchmark`
- [ ] The change is covered by end-to-end integration test

### Pull Request Checklist

- [x] I have filled in all the required field in the template
- [x] I have tested locally that all the tests pass
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.

