### PR TITLE
fixed matmul variable to use free dim tile size instead of the contraction dim tile

### DIFF
--- a/src/nki_samples/tutorials/matrix_multiplication/matrix_multiplication_nki_kernels.py
+++ b/src/nki_samples/tutorials/matrix_multiplication/matrix_multiplication_nki_kernels.py
@@ -376,9 +376,9 @@ def nki_matmul_fully_optimized_(
     # Copying the result from SBUF to HBM
     for m in nl.affine_range(NUM_BLOCK_M):
       for bm in nl.affine_range(TILES_IN_BLOCK_M):
-        i_res = nl.mgrid[0:TILE_K, 0:TILE_N]
-        i_res_packed = nl.mgrid[0:TILE_K, 0:BLOCK_N]
-        result_packed = nl.ndarray((TILE_K, BLOCK_N),
+        i_res = nl.mgrid[0:TILE_M, 0:TILE_N]
+        i_res_packed = nl.mgrid[0:TILE_M, 0:BLOCK_N]
+        result_packed = nl.ndarray((TILE_M, BLOCK_N),
                                    dtype=result_tiles.dtype,
                                    buffer=nl.sbuf)
 
@@ -388,7 +388,7 @@ def nki_matmul_fully_optimized_(
                         bn * TILE_N + i_res.x] = nl.copy(result_tiles[m, bm, bn,
                                                                       i_res.p,
                                                                       i_res.x])
-        nl.store(result[(TILES_IN_BLOCK_M * m + bm) * TILE_K + i_res_packed.p,
+        nl.store(result[(TILES_IN_BLOCK_M * m + bm) * TILE_M + i_res_packed.p,
                         BLOCK_N * n + i_res_packed.x],
                  value=result_packed[i_res_packed.p, i_res_packed.x])
 


### PR DESCRIPTION
### Description of changes:
Changed incorrect usage of `TILE_K` variable to use the free dimension `TILE_M` variable.
The code works correctly because `TILE_K` == `TILE_M` but logically `TILE_M` is the correct variable to be used here
### Pull Request Checklist

- [x] I have filled in all the required field in the template
- [x] I have tested locally that all the tests pass
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.

