### PR TITLE
Update warmup and iters for test_allocated_SD_attention_small_head performance test

### DIFF
--- a/test/unit/test_allocated_SD_attention_small_head.py
+++ b/test/unit/test_allocated_SD_attention_small_head.py
@@ -12,7 +12,7 @@ from scipy.special import softmax
 
 test_trace_file_path='local_trace.ntff'
 
-bench_func = benchmark(warmup=5, iters=20, save_trace_name=test_trace_file_path)(allocated_fused_self_attn_for_SD_small_head_size)
+bench_func = benchmark(warmup=20, iters=200, save_trace_name=test_trace_file_path)(allocated_fused_self_attn_for_SD_small_head_size)
 
 def cpu_golden_attn(q, k, v):
     softmax_scale = 0.125


### PR DESCRIPTION
With low warmup iterations (5) and benchmark iterations (20), the p50 latency for the `test_allocated_SD_attention_small_head` performance test was a bit unstable. Increasing the warmup iterations to 20 and benchmark iterations to 200 to reduce variance of test results.

----
By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.

