### PR TITLE
[Test] Relax latency threshold because the test fluctuate

### DIFF
--- a/test/unit/test_SD_attention_small_head.py
+++ b/test/unit/test_SD_attention_small_head.py
@@ -25,9 +25,9 @@ def cpu_golden_attn(q, k, v):
 class TestAttention:
 
     @pytest.mark.parametrize("bs,seqlen,d,dtype,latency", [
-        [1, 4096, 128, np.float32, 600],
+        [1, 4096, 128, np.float32, 675],
         [1, 4096, 128, nl.bfloat16, 480],
-        [1, 4096, 64, nl.float16, 520]
+        [1, 4096, 64, nl.float16, 600]
     ])
     def test_attention_for_SD_perf(self, bs, seqlen, d, dtype, latency):
         q = np.random.random_sample((bs, d, seqlen)).astype(np.float32)


### PR DESCRIPTION
### Issue #, if available:
N/A

### Description of changes:
Relax latency threshold because the test fluctuate

### Testing:

Please see detailed unit test requirements in the [CONTRIBUTING.md](https://github.com/aws-neuron/nki-samples/blob/main/CONTRIBUTING.md)

- [ ] The change is covered by numeric check using `nki.baremetal`
- [ ] The change is covered by performance benchmark test using `nki.benchmark`
- [ ] The change is covered by end-to-end integration test

### Pull Request Checklist

- [ ] I have filled in all the required field in the template
- [ ] I have tested locally that all the tests pass
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.

