### PR TITLE
update for 2.29 | NKI beta 3 

### DIFF
--- a/src/nki_samples/tutorials/matrix_multiplication/matrix_multiplication_nki_kernels.py
+++ b/src/nki_samples/tutorials/matrix_multiplication/matrix_multiplication_nki_kernels.py
@@ -56,7 +56,7 @@ def nki_matmul_basic_(lhsT, rhs):
 
   # Create a tensor in SBUF and copy the result from PSUM back to SBUF, and cast to expected output data-type
   result_sbuf = nl.ndarray(result_psum.shape, dtype=result.dtype, buffer=nl.sbuf)
-  nisa.tensor_copy(dst=result_sbuf, src=result_psum, dtype=result.dtype)
+  nisa.tensor_copy(dst=result_sbuf, src=result_psum)
 
   # The result of a [64,128] x [128,512] matrix multiplication has a shape of [64, 512].
   # This dictates which indices to use to address the result tile.
@@ -124,7 +124,7 @@ def nki_matmul_tiled_(lhsT, rhs):
 
       # Copy the result from PSUM back to SBUF, and cast to expected output data-type
       res_sb = nl.ndarray(res_psum.shape, dtype=result.dtype, buffer=nl.sbuf)
-      nisa.tensor_copy(dst=res_sb, src=res_psum, dtype=result.dtype)
+      nisa.tensor_copy(dst=res_sb, src=res_psum)
 
       # Copy the result from SBUF to HBM.
       nisa.dma_copy(dst=result[m * TILE_M:(m + 1) * TILE_M, n * TILE_N:(n + 1) * TILE_N], src=res_sb)
@@ -203,8 +203,8 @@ def nki_matmul_hoist_load_(lhsT, rhs):
         nisa.nc_matmul(dst=res_psum, stationary=lhsT_tiles[k], moving=rhs_tiles[k])
 
       # Copy the result from PSUM back to SBUF, and cast to expected output data-type
-      res_sb = nl.ndarray(shape=(TILE_M, TILE_N), dtype=nl.float32, buffer=nl.sbuf)
-      nisa.tensor_copy(dst=res_sb, src=res_psum, dtype=result.dtype)
+      res_sb = nl.ndarray(shape=(TILE_M, TILE_N), dtype=result.dtype, buffer=nl.sbuf)
+      nisa.tensor_copy(dst=res_sb, src=res_psum)
 
       # Copy the result from SBUF to HBM.
       nisa.dma_copy(dst=result[m * TILE_M:(m + 1) * TILE_M, n * TILE_N:(n + 1) * TILE_N], src=res_sb)
@@ -386,8 +386,8 @@ def nki_matmul_fully_optimized_(
         for bn_idx in range(TILES_IN_BLOCK_N):
           # Create the result tile (uninitialized)
           tile = nl.ndarray(shape=(TILE_M, TILE_N), dtype=lhsT.dtype, buffer=nl.sbuf)
-          # Initialize the tile 0.0
-          nisa.memset(dst=tile, value=0.0)
+          # Initialize the tile to 0
+          nisa.memset(dst=tile, value=0)
           # Append the tile to block_n array.
           block_n.append(tile)
         # Append block_n array to block_m array.


### PR DESCRIPTION
### Issue #, if available:

N/A

### Description of changes:

  1. nisa.memset strict type matching — Changed value=0.0 to value=0 in nki_matmul_fully_optimized_. NKI 0.3.0 enforces that the value literal must match the destination tensor's dtype; 0.0 (Python float64) is a type mismatch against lhsT.dtype.
  2. nisa.tensor_copy — removed deprecated dtype parameter — The dtype keyword argument has been removed from nisa.tensor_copy in NKI 0.3.0. Removed from three call sites across nki_matmul_basic_, nki_matmul_tiled_, and nki_matmul_hoist_load_. The cast is now expressed entirely through the destination tensor's declared dtype.
  3. nki_matmul_hoist_load_ — corrected res_sb allocation dtype — The res_sb SBUF buffer was incorrectly declared as nl.float32 while the intent was to store the final output-typed result. Changed to result.dtype to align with the other kernels and correctly express the PSUM→output dtype cast via the destination allocation.

### Testing:

Please see detailed unit test requirements in the [CONTRIBUTING.md](https://github.com/aws-neuron/nki-samples/blob/main/CONTRIBUTING.md)

- [ ] The change is covered by numeric check using `nki.baremetal`
- [ ] The change is covered by performance benchmark test using `nki.benchmark`
- [ ] The change is covered by end-to-end integration test

### Pull Request Checklist

- [X] I have filled in all the required field in the template
- [X] I have tested locally that all the tests pass
- [X] By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.

