### PR TITLE
fix: validate chunk_size and source dim in interpolate_{bi,tri}linear_2x_fwd

### DIFF
--- a/contributed/interpolate_bilinear_fwd.py
+++ b/contributed/interpolate_bilinear_fwd.py
@@ -45,6 +45,8 @@ def interpolate_bilinear_2x_fwd(src_arr: nt.tensor, chunk_size: int = 10) -> Non
     assert c_src == c_dst, "Input channel and output channel sizes must be identical"
     assert h_dst == 2 * h_src, "Output height must be twice the input height"
     assert w_dst == 2 * w_src, "Output width must be twice the input width"
+    assert chunk_size >= 2, "chunk_size must be >= 2 (step_size = chunk_size - 1 must be positive)"
+    assert h_src >= chunk_size, "h_src must be >= chunk_size to form at least one chunk"
     n, c = n_src, c_src
 
     weight_1d = 1 / 4 # specific to scaling_factor=2.0 & align_corners=False

--- a/contributed/interpolate_trilinear_fwd.py
+++ b/contributed/interpolate_trilinear_fwd.py
@@ -53,6 +53,8 @@ def interpolate_trilinear_2x_fwd(src_arr: nt.tensor, chunk_size: int = 4) -> nt.
     assert d_dst == 2 * d_src, "Output depth must be twice the input depth"
     assert h_dst == 2 * h_src, "Output height must be twice the input height"
     assert w_dst == 2 * w_src, "Output width must be twice the input width"
+    assert chunk_size >= 2, "chunk_size must be >= 2 (step_size = chunk_size - 1 must be positive)"
+    assert d_src >= chunk_size, "d_src must be >= chunk_size to form at least one chunk"
 
     n, c = n_src, c_src
     


### PR DESCRIPTION
…

interpolate_bilinear_2x_fwd and interpolate_trilinear_2x_fwd computed their loop trip count as math.ceil((dim - chunk_size) / (chunk_size - 1)) + 1. chunk_size == 1 made the divisor zero and raised ZeroDivisionError at trace time before any nl call. Source dim < chunk_size silently evaluated to a zero-trip loop, allocated dst_arr without writing to it, and returned uninitialized HBM to the caller.

Both kernels now assert the preconditions the chunking math already required: chunk_size >= 2 (so step_size is positive) and the chunked source dim >= chunk_size (so the loop runs at least once). Default chunk_size values (10 bilinear, 4 trilinear) are unaffected.

Fixes aws-neuron/nki-samples#125.
