### PR TITLE
[#127] Check the pool_size is nonzero in tensor_avgpool_kernel

### DIFF
--- a/src/nki_samples/tutorials/average_pool2d/average_pool2d_nki_kernels.py
+++ b/src/nki_samples/tutorials/average_pool2d/average_pool2d_nki_kernels.py
@@ -22,6 +22,7 @@ def tensor_avgpool_kernel(in_tensor, pool_size):
   Return:
       out_tensor: the resulting output tensor, of shape C x (H/pool_size) x (W/pool_size)
   """
+  ssert pool_size >= 1, "pool_size must be >= 1"
 
   # Get input/output dimensions
   sz_cin, sz_hin, sz_win = in_tensor.shape

--- a/src/nki_samples/tutorials/average_pool2d/average_pool2d_nki_kernels.py
+++ b/src/nki_samples/tutorials/average_pool2d/average_pool2d_nki_kernels.py
@@ -22,7 +22,7 @@ def tensor_avgpool_kernel(in_tensor, pool_size):
   Return:
       out_tensor: the resulting output tensor, of shape C x (H/pool_size) x (W/pool_size)
   """
-  ssert pool_size >= 1, "pool_size must be >= 1"
+  assert pool_size >= 1, "pool_size must be >= 1"
 
   # Get input/output dimensions
   sz_cin, sz_hin, sz_win = in_tensor.shape


### PR DESCRIPTION
### Issue #, if available:

127

### Description of changes:
Check the pool_size is nonzero in tensor_avgpool_kernel

### Testing:

- [*] The change is covered by numeric check using `nki.baremetal`
- [ ] The change is covered by performance benchmark test using `nki.benchmark`
- [ ] The change is covered by end-to-end integration test

### Pull Request Checklist

- [* ] I have filled in all the required field in the template
- [ *] I have tested locally that all the tests pass
- [ *] By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.

