### PR TITLE
Update tutorials for Neuron SDK 2.32 release (NKI 0.6.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ purpose built for AI workloads.
 At the core of the Neuron SDK is the Neuron Compiler, which takes computation graphs from frameworks like PyTorch and JAX and converts
 them into highly optimized machine code.
 
-[NKI](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/general/nki) is a Python-based programming environment designed for the compiler which
+[NKI](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/general/nki/) is a Python-based programming environment designed for the compiler which
 adopts commonly used NumPy and Triton-like syntax along with tile-level semantics.
 NKI also interoperates with the Neuron Profiler, providing insights into performance bottlenecks and instruction latencies.
 It offers tensor printing support, standard error messaging, and built-in kernel simulation capabilities for efficient debugging purposes.
@@ -14,8 +14,6 @@ NKI Language ([nki.language](https://awsdocs-neuron.readthedocs-hosted.com/en/la
 NKI Instruction Set Architecture ([nki.isa](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/general/nki/api/nki.isa.html)),
 enabling bare-metal access to the chip for full control.
 
-![alt "High-level flow of NKI in the Neuron Compiler. NKI emits IR immediately before the backend-IR compilation stage"](doc_assets/high-level-nki-flow.png#center "High-Level NKI Flow")
-
 ## Documentation
 The latest NKI documentation can be found on the AWS Documentation site, [here](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/general/nki/).
 Documentation for NKI kernels are both inline (docstring) and available on the documentation site's
@@ -23,9 +21,7 @@ Documentation for NKI kernels are both inline (docstring) and available on the d
 
 ## Repository Structure
 
-### src
-
-#### tutorials
+### src/nki_samples/tutorials
 The [tutorial kernels](src/nki_samples/tutorials/) are for educational purpose and include the kernels that are used in NKI guides.
 You can clone these sample kernels and run them directly while reading through the
 [NKI documentation](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/general/nki/tutorials.html). These kernels are not necessarily high-performance,

--- a/src/nki_samples/tutorials/attention_fwd_performance/attention_kernels.py
+++ b/src/nki_samples/tutorials/attention_fwd_performance/attention_kernels.py
@@ -158,17 +158,17 @@ def attn_fwd_v3(q, k, v):
     v_sbuf = nl.load(v)
 
     # Tile along seqlen_q #
-    # for this example we assume that seqlen_q is divisible by PMAX and 
+    # for this example we assume that seqlen_q is divisible by PMAX and
     # seqlen_kv is divisible by FMAX_MOVING, otherwise need to use mask or "final multiplication"
     qk = nl.ndarray((seqlen_q // PMAX, seqlen_kv // FMAX_MOVING, PMAX, FMAX_MOVING),
                      dtype=nl.float32, buffer=nl.shared_hbm)
-    for i_tile_q in nl.affine_range(seqlen_q // FMAX_STATIONARY): # loop on stationary_free
-        for i_tile_kv in nl.affine_range(seqlen_kv // FMAX_MOVING): # loop on moving_free
+    for i_tile_q in range(seqlen_q // FMAX_STATIONARY): # loop on stationary_free
+        for i_tile_kv in range(seqlen_kv // FMAX_MOVING): # loop on moving_free
             # Q @ K, contract along d_head #
             qk_psum = nl.ndarray((PMAX, FMAX_MOVING), dtype=nl.float32, buffer=nl.psum)
-            nisa.nc_matmul(dst=qk_psum, 
-                stationary=q_sbuf[0:PMAX, nl.ds(i_tile_q*FMAX_STATIONARY, FMAX_STATIONARY)],
-                moving=k_sbuf[0:PMAX, nl.ds(i_tile_kv*FMAX_MOVING, FMAX_MOVING)])
+            nisa.nc_matmul(dst=qk_psum,
+                stationary=q_sbuf[0:PMAX, i_tile_q*FMAX_STATIONARY:i_tile_q*FMAX_STATIONARY+FMAX_STATIONARY],
+                moving=k_sbuf[0:PMAX, i_tile_kv*FMAX_MOVING:i_tile_kv*FMAX_MOVING+FMAX_MOVING])
             qk_sbuf = nl.ndarray((PMAX, FMAX_MOVING), dtype=nl.float32, buffer=nl.sbuf)
             nisa.tensor_copy(dst=qk_sbuf, src=qk_psum)
             nisa.dma_copy(dst=qk[i_tile_q, i_tile_kv, :, :], src=qk_sbuf)
@@ -176,33 +176,33 @@ def attn_fwd_v3(q, k, v):
     # Softmax #
     # reduce max along seqlen_k
     row_max = nl.ndarray((PMAX, seqlen_q // PMAX), dtype=nl.float32, buffer=nl.sbuf)
-    for i_tile_q in nl.affine_range(seqlen_q // PMAX):
+    for i_tile_q in range(seqlen_q // PMAX):
 
         row_max_kv = nl.ndarray((PMAX, seqlen_kv // FMAX_MOVING), dtype=nl.float32, buffer=nl.sbuf)
-        for i_tile_kv in nl.affine_range(seqlen_kv // FMAX_MOVING):
+        for i_tile_kv in range(seqlen_kv // FMAX_MOVING):
             qk_tile = nl.ndarray((PMAX, FMAX_MOVING), dtype=nl.float32, buffer=nl.sbuf)
             nisa.dma_copy(dst=qk_tile, src=qk[i_tile_q, i_tile_kv, :, :])
-            nisa.tensor_reduce(dst=row_max_kv[:, nl.ds(i_tile_kv, 1)], op=nl.maximum, data=qk_tile, axis=(1,))
- 
-        nisa.tensor_reduce(dst=row_max[:, nl.ds(i_tile_q, 1)], op=nl.maximum, data=row_max_kv[:, :], axis=(1,))
+            nisa.tensor_reduce(dst=row_max_kv[:, i_tile_kv:i_tile_kv+1], op=nl.maximum, data=qk_tile, axis=(1,))
+
+        nisa.tensor_reduce(dst=row_max[:, i_tile_q:i_tile_q+1], op=nl.maximum, data=row_max_kv[:, :], axis=(1,))
 
     # subtract max from row
     norm_row = nl.ndarray((seqlen_q // PMAX, PMAX, seqlen_kv),
                        dtype=nl.float32, buffer=nl.shared_hbm)
-    for i_tile_q in nl.affine_range(seqlen_q // PMAX):
+    for i_tile_q in range(seqlen_q // PMAX):
         norm_buf = nl.ndarray(shape=(PMAX, seqlen_kv), dtype=nl.float32, buffer=nl.sbuf)
-        for i_tile_kv in nl.affine_range(seqlen_kv // FMAX_MOVING):
+        for i_tile_kv in range(seqlen_kv // FMAX_MOVING):
             qk_tile_sub = nl.ndarray((PMAX, FMAX_MOVING), dtype=nl.float32, buffer=nl.sbuf)
             nisa.dma_copy(dst=qk_tile_sub, src=qk[i_tile_q, i_tile_kv, :, :])
-            nisa.tensor_scalar(dst=norm_buf[:, nl.ds(i_tile_kv*FMAX_MOVING, FMAX_MOVING)], 
+            nisa.tensor_scalar(dst=norm_buf[:, i_tile_kv*FMAX_MOVING:i_tile_kv*FMAX_MOVING+FMAX_MOVING],
                 data=qk_tile_sub,
                 op0=nl.subtract,
-                operand0=row_max[:, nl.ds(i_tile_q, 1)])
+                operand0=row_max[:, i_tile_q:i_tile_q+1])
         nl.store(norm_row[i_tile_q], norm_buf[:,:])
 
     # exponentiation
     exp_row = nl.ndarray((seqlen_q // PMAX, PMAX, seqlen_kv), dtype=nl.float32, buffer=nl.shared_hbm)
-    for i_tile_q in nl.affine_range(seqlen_q // PMAX):
+    for i_tile_q in range(seqlen_q // PMAX):
         # norm_buf = nl.ndarray(shape=(PMAX, seqlen_kv), dtype=nl.float32, buffer=nl.sbuf)
         exp_buf = nl.ndarray(shape=(PMAX, seqlen_kv), dtype=nl.float32, buffer=nl.sbuf)
         norm_buf = nl.load(norm_row[i_tile_q])
@@ -211,31 +211,30 @@ def attn_fwd_v3(q, k, v):
 
     # sum of exp results
     sum_row = nl.ndarray((PMAX, seqlen_q // PMAX), dtype=nl.float32, buffer=nl.sbuf)
-    for i_tile_q in nl.affine_range(seqlen_q // PMAX):
+    for i_tile_q in range(seqlen_q // PMAX):
         exp_buf = nl.load(exp_row[i_tile_q])
-        nisa.tensor_reduce(dst=sum_row[:, nl.ds(i_tile_q, 1)], op=nl.add,
+        nisa.tensor_reduce(dst=sum_row[:, i_tile_q:i_tile_q+1], op=nl.add,
                                                          data=exp_buf,
                                                          axis=(1,))
 
     # reciprocal of sum_row, tile shape is [PMAX, seqlen_q // PMAX]
     inverse_sum_row = nl.ndarray(sum_row.shape, dtype=nl.float32, buffer=nl.sbuf)
     nisa.reciprocal(dst=inverse_sum_row, data=sum_row)
-    
     scores = nl.ndarray((seqlen_q // PMAX, PMAX, seqlen_kv), dtype=nl.float32, buffer=nl.shared_hbm)
-    for i_tile_q in nl.affine_range(seqlen_q // PMAX):
+    for i_tile_q in range(seqlen_q // PMAX):
         scores_buf = nl.ndarray(shape=(PMAX, seqlen_kv), dtype=nl.float32, buffer=nl.sbuf)
         exp_buf = nl.load(exp_row[i_tile_q])
         nisa.tensor_scalar(dst=scores_buf[:,:], data=exp_buf,
                                                op0=nl.multiply,
                                                operand0=inverse_sum_row[:, i_tile_q])
         nl.store(scores[i_tile_q], scores_buf[:,:])
-        
+
     # v has the wrong layout
     v_t = nl.ndarray((seqlen_kv // PMAX, PMAX, d_head), dtype=nl.float32, buffer=nl.shared_hbm)
-    for i_tile_kv in nl.affine_range(seqlen_kv // PMAX):
+    for i_tile_kv in range(seqlen_kv // PMAX):
         v_psum_t = nl.ndarray((PMAX, d_head), dtype=v_sbuf.dtype, buffer=nl.psum)
         v_psum_t = nl.ndarray((PMAX, d_head), dtype=v_sbuf.dtype, buffer=nl.psum)
-        nisa.nc_transpose(dst=v_psum_t, data=v_sbuf[:, nl.ds(i_tile_kv*PMAX, PMAX)]) # TensorE
+        nisa.nc_transpose(dst=v_psum_t, data=v_sbuf[:, i_tile_kv*PMAX:i_tile_kv*PMAX+PMAX]) # TensorE
         v_sbuf_t = nl.ndarray((PMAX, d_head), dtype=nl.float32, buffer=nl.sbuf)
         nisa.tensor_copy(dst=v_sbuf_t[:, :], src=v_psum_t)                   # ScalarE
         nl.store(v_t[i_tile_kv], v_sbuf_t[:,:])
@@ -245,9 +244,9 @@ def attn_fwd_v3(q, k, v):
     # scores_sbuf_t = nl.ndarray((PMAX, seqlen_kv // PMAX, seqlen_q // PMAX, PMAX),
     #                            dtype=nl.float32, buffer=nl.sbuf)
     scores_t = nl.ndarray((seqlen_kv // PMAX, seqlen_q // PMAX, PMAX, PMAX), dtype=nl.float32, buffer=nl.shared_hbm)
-    for i_tile_q in nl.affine_range(seqlen_q // PMAX):
-        for i_tile_kv in nl.affine_range(seqlen_kv // PMAX):
-            scores_buf = nl.load(scores[i_tile_q, :, nl.ds(i_tile_kv*PMAX, PMAX)])
+    for i_tile_q in range(seqlen_q // PMAX):
+        for i_tile_kv in range(seqlen_kv // PMAX):
+            scores_buf = nl.load(scores[i_tile_q, :, i_tile_kv*PMAX:i_tile_kv*PMAX+PMAX])
             scores_psum_t = nl.ndarray((PMAX, PMAX), dtype=nl.float32, buffer=nl.psum)
             nisa.nc_transpose(dst=scores_psum_t, data=scores_buf) # TensorE
             scores_sbuf_t = nl.ndarray((PMAX, PMAX), dtype=nl.float32, buffer=nl.sbuf)
@@ -256,25 +255,25 @@ def attn_fwd_v3(q, k, v):
 
     # scores @ V, contract along seqlen_kv
     # d_head == P_MAX, no need to tile there
-    for i_tile_q in nl.affine_range(seqlen_q // PMAX): # loop on stationary free
+    for i_tile_q in range(seqlen_q // PMAX): # loop on stationary free
         attn_out_psum = nl.zeros((PMAX, PMAX), dtype=nl.float32, buffer=nl.psum)
         attn_out = nl.ndarray((PMAX, d_head),
                            dtype=nl.float32, buffer=nl.sbuf)
-        for i_tile_kv in nl.affine_range(seqlen_kv // PMAX): # loop on contraction
+        for i_tile_kv in range(seqlen_kv // PMAX): # loop on contraction
             scores_sbuf_t = nl.load(scores_t[i_tile_kv, i_tile_q, :, :])
             v_sbuf_t = nl.load(v_t[i_tile_kv, :, :])
             nisa.nc_matmul(dst=attn_out_psum, stationary=scores_sbuf_t,
                                             moving=v_sbuf_t)
         nisa.tensor_copy(dst=attn_out, src=attn_out_psum)
-        nl.store(dst=kernel_out[nl.ds(i_tile_q*PMAX, PMAX), :], value=attn_out[:,:])
+        nl.store(dst=kernel_out[i_tile_q*PMAX:i_tile_q*PMAX+PMAX, :], value=attn_out[:,:])
 
     return kernel_out
 
 
 ####################################################################
 # v4: Loop fusion
-# combines QK matrix multiplication, all softmax steps, and V 
-# multiplication to compute attention scores & output under one 
+# combines QK matrix multiplication, all softmax steps, and V
+# multiplication to compute attention scores & output under one
 # common loop.
 ####################################################################
 @nki.jit
@@ -299,15 +298,15 @@ def attn_fwd_v4(q, k, v):
 
     # v has the wrong layout
     v_sbuf_t = nl.ndarray((PMAX, seqlen_kv // PMAX, d_head), dtype=nl.float32, buffer=nl.sbuf)
-    for i_tile_kv in nl.affine_range(seqlen_kv // PMAX):
+    for i_tile_kv in range(seqlen_kv // PMAX):
         v_psum_t = nl.ndarray((PMAX, d_head), dtype=v_sbuf.dtype, buffer=nl.psum)
-        nisa.nc_transpose(dst=v_psum_t, data=v_sbuf[:, nl.ds(i_tile_kv*PMAX, PMAX)]) # TensorE
+        nisa.nc_transpose(dst=v_psum_t, data=v_sbuf[:, i_tile_kv*PMAX:i_tile_kv*PMAX+PMAX]) # TensorE
         nisa.tensor_copy(dst=v_sbuf_t[:, i_tile_kv, :], src=v_psum_t)     # ScalarE
 
     num_kv_tiles = seqlen_kv // FMAX_MOVING
 
     # Tile along seqlen_q #
-    for i_tile_q in nl.affine_range(seqlen_q // FMAX_STATIONARY): # loop on stationary_free
+    for i_tile_q in range(seqlen_q // FMAX_STATIONARY): # loop on stationary_free
         # per i_tile_q we finish a partial block matrix for qk
         # Allocate fresh PSUM tiles each iteration to avoid accumulation
         qk_tiles = []
@@ -316,9 +315,9 @@ def attn_fwd_v4(q, k, v):
 
         for i_tile_kv in range(num_kv_tiles): # loop on moving_free
             # Q @ K, contract along d_head #
-            nisa.nc_matmul(dst=qk_tiles[i_tile_kv], 
-                stationary=q_sbuf[0:PMAX, nl.ds(i_tile_q*FMAX_STATIONARY, FMAX_STATIONARY)],
-                moving=k_sbuf[0:PMAX, nl.ds(i_tile_kv*FMAX_MOVING, FMAX_MOVING)])
+            nisa.nc_matmul(dst=qk_tiles[i_tile_kv],
+                stationary=q_sbuf[0:PMAX, i_tile_q*FMAX_STATIONARY:i_tile_q*FMAX_STATIONARY+FMAX_STATIONARY],
+                moving=k_sbuf[0:PMAX, i_tile_kv*FMAX_MOVING:i_tile_kv*FMAX_MOVING+FMAX_MOVING])
 
         # Softmax #
         # reduce max along seqlen_k
@@ -326,7 +325,7 @@ def attn_fwd_v4(q, k, v):
 
         row_max_kv = nl.ndarray((PMAX, num_kv_tiles), dtype=nl.float32, buffer=nl.sbuf)
         for i_tile_kv in range(num_kv_tiles):
-            nisa.tensor_reduce(dst=row_max_kv[:, nl.ds(i_tile_kv, 1)], op=nl.maximum, data=qk_tiles[i_tile_kv], axis=(1,))
+            nisa.tensor_reduce(dst=row_max_kv[:, i_tile_kv:i_tile_kv+1], op=nl.maximum, data=qk_tiles[i_tile_kv], axis=(1,))
 
         nisa.tensor_reduce(dst=row_max[:, :], op=nl.maximum, data=row_max_kv[:, :], axis=(1,))
 
@@ -334,23 +333,23 @@ def attn_fwd_v4(q, k, v):
         norm_row = nl.ndarray((PMAX, seqlen_kv),
                             dtype=nl.float32, buffer=nl.sbuf)
         for i_tile_kv in range(num_kv_tiles):
-            nisa.tensor_scalar(dst=norm_row[:, nl.ds(i_tile_kv*FMAX_MOVING, FMAX_MOVING)], 
+            nisa.tensor_scalar(dst=norm_row[:, i_tile_kv*FMAX_MOVING:i_tile_kv*FMAX_MOVING+FMAX_MOVING],
                 data=qk_tiles[i_tile_kv],
                 op0=nl.subtract,
                 operand0=row_max)
 
         # exponentiation
         exp_row = nl.ndarray((PMAX, seqlen_kv), dtype=nl.float32, buffer=nl.sbuf)
-        for i_tile_kv in nl.affine_range(seqlen_kv // FMAX_MOVING):
-            nisa.activation(dst=exp_row[:, nl.ds(i_tile_kv*FMAX_MOVING, FMAX_MOVING)], 
-                op=nl.exp, data=norm_row[:, nl.ds(i_tile_kv*FMAX_MOVING, FMAX_MOVING)])
+        for i_tile_kv in range(seqlen_kv // FMAX_MOVING):
+            nisa.activation(dst=exp_row[:, i_tile_kv*FMAX_MOVING:i_tile_kv*FMAX_MOVING+FMAX_MOVING],
+                op=nl.exp, data=norm_row[:, i_tile_kv*FMAX_MOVING:i_tile_kv*FMAX_MOVING+FMAX_MOVING])
 
         # sum of exp results
         sum_row_kv = nl.ndarray((PMAX, seqlen_kv // FMAX_MOVING), dtype=nl.float32, buffer=nl.sbuf)
-        for i_tile_kv in nl.affine_range(seqlen_kv // FMAX_MOVING):
-            nisa.tensor_reduce(dst=sum_row_kv[:, nl.ds(i_tile_kv, 1)], 
+        for i_tile_kv in range(seqlen_kv // FMAX_MOVING):
+            nisa.tensor_reduce(dst=sum_row_kv[:, i_tile_kv:i_tile_kv+1],
                 op=nl.add,
-                data=exp_row[:, nl.ds(i_tile_kv*FMAX_MOVING, FMAX_MOVING)], axis=(1,))
+                data=exp_row[:, i_tile_kv*FMAX_MOVING:i_tile_kv*FMAX_MOVING+FMAX_MOVING], axis=(1,))
 
         sum_row = nl.ndarray((PMAX, 1), dtype=nl.float32, buffer=nl.sbuf)
         nisa.tensor_reduce(dst=sum_row, op=nl.add, data=sum_row_kv, axis=(1,))
@@ -362,18 +361,18 @@ def attn_fwd_v4(q, k, v):
         nisa.reciprocal(dst=inverse_sum_row, data=sum_row)
 
         scores = nl.ndarray((PMAX, seqlen_kv), dtype=nl.float32, buffer=nl.sbuf)
-        for i_tile_kv in nl.affine_range(seqlen_kv // FMAX_MOVING):
-            nisa.tensor_scalar(dst=scores[:, nl.ds(i_tile_kv*FMAX_MOVING, FMAX_MOVING)], 
-                data=exp_row[:, nl.ds(i_tile_kv*FMAX_MOVING, FMAX_MOVING)],
+        for i_tile_kv in range(seqlen_kv // FMAX_MOVING):
+            nisa.tensor_scalar(dst=scores[:, i_tile_kv*FMAX_MOVING:i_tile_kv*FMAX_MOVING+FMAX_MOVING],
+                data=exp_row[:, i_tile_kv*FMAX_MOVING:i_tile_kv*FMAX_MOVING+FMAX_MOVING],
                 op0=nl.multiply,
                 operand0=inverse_sum_row)
 
         # scores has the wrong layout
         scores_sbuf_t = nl.ndarray((PMAX, seqlen_kv // PMAX, PMAX),
                                     dtype=nl.float32, buffer=nl.sbuf)
-        for i_tile_kv in nl.affine_range(seqlen_kv // PMAX):
+        for i_tile_kv in range(seqlen_kv // PMAX):
             scores_psum_t = nl.ndarray((PMAX, PMAX), dtype=nl.float32, buffer=nl.psum)
-            nisa.nc_transpose(dst=scores_psum_t, data=scores[:, nl.ds(i_tile_kv*PMAX, PMAX)]) # TensorE
+            nisa.nc_transpose(dst=scores_psum_t, data=scores[:, i_tile_kv*PMAX:i_tile_kv*PMAX+PMAX]) # TensorE
             nisa.tensor_copy(dst=scores_sbuf_t[:, i_tile_kv, :], src=scores_psum_t)    # ScalarE
 
         # scores @ V, contract along seqlen_kv
@@ -382,11 +381,11 @@ def attn_fwd_v4(q, k, v):
 
         attn_out_psum = nl.zeros((PMAX, PMAX), dtype=nl.float32, buffer=nl.psum)
 
-        for i_tile_kv in nl.affine_range(seqlen_kv // PMAX): # loop on contraction
+        for i_tile_kv in range(seqlen_kv // PMAX): # loop on contraction
             nisa.nc_matmul(dst=attn_out_psum, stationary=scores_sbuf_t[:, i_tile_kv, :],
                                             moving=v_sbuf_t[:, i_tile_kv, :])
         nisa.tensor_copy(dst=attn_out, src=attn_out_psum) # store output
-        nl.store(dst=kernel_out[nl.ds(i_tile_q*PMAX, PMAX), :], value=attn_out[:, :])
+        nl.store(dst=kernel_out[i_tile_q*PMAX:i_tile_q*PMAX+PMAX, :], value=attn_out[:, :])
 
     return kernel_out
 
@@ -416,15 +415,15 @@ def attn_fwd_v5(q, k, v):
 
     # v has the wrong layout
     v_sbuf_t = nl.ndarray((PMAX, seqlen_kv // PMAX, PMAX), dtype=nl.float32, buffer=nl.sbuf)
-    for i_tile_kv in nl.affine_range(seqlen_kv // PMAX):
+    for i_tile_kv in range(seqlen_kv // PMAX):
         v_psum_t = nl.ndarray((PMAX, d_head), dtype=v_sbuf.dtype, buffer=nl.psum)
-        nisa.nc_transpose(dst=v_psum_t, data=v_sbuf[:, nl.ds(i_tile_kv*PMAX, PMAX)]) # TensorE
+        nisa.nc_transpose(dst=v_psum_t, data=v_sbuf[:, i_tile_kv*PMAX:i_tile_kv*PMAX+PMAX]) # TensorE
         nisa.tensor_copy(dst=v_sbuf_t[:, i_tile_kv, :], src=v_psum_t)     # ScalarE
 
     num_kv_tiles = seqlen_kv // FMAX_MOVING
 
     # Tile along seqlen_q #
-    for i_tile_q in nl.affine_range(seqlen_q // FMAX_STATIONARY): # loop on stationary_free
+    for i_tile_q in range(seqlen_q // FMAX_STATIONARY): # loop on stationary_free
         # Allocate fresh PSUM tiles each iteration to avoid accumulation
         qk_tiles = []
         for _i in range(num_kv_tiles):
@@ -432,9 +431,9 @@ def attn_fwd_v5(q, k, v):
 
         for i_tile_kv in range(num_kv_tiles): # loop on moving_free
             # Q @ K, contract along d_head #
-            nisa.nc_matmul(dst=qk_tiles[i_tile_kv], 
-                stationary=q_sbuf[0:PMAX, nl.ds(i_tile_q*FMAX_STATIONARY, FMAX_STATIONARY)],
-                moving=k_sbuf[0:PMAX, nl.ds(i_tile_kv*FMAX_MOVING, FMAX_MOVING)])
+            nisa.nc_matmul(dst=qk_tiles[i_tile_kv],
+                stationary=q_sbuf[0:PMAX, i_tile_q*FMAX_STATIONARY:i_tile_q*FMAX_STATIONARY+FMAX_STATIONARY],
+                moving=k_sbuf[0:PMAX, i_tile_kv*FMAX_MOVING:i_tile_kv*FMAX_MOVING+FMAX_MOVING])
 
         # Softmax #
         # reduce max along seqlen_k
@@ -442,7 +441,7 @@ def attn_fwd_v5(q, k, v):
 
         row_max_kv = nl.ndarray((PMAX, num_kv_tiles), dtype=nl.float32, buffer=nl.sbuf)
         for i_tile_kv in range(num_kv_tiles):
-            nisa.tensor_reduce(dst=row_max_kv[:, nl.ds(i_tile_kv, 1)], op=nl.maximum, data=qk_tiles[i_tile_kv], axis=(1,))
+            nisa.tensor_reduce(dst=row_max_kv[:, i_tile_kv:i_tile_kv+1], op=nl.maximum, data=qk_tiles[i_tile_kv], axis=(1,))
 
         nisa.tensor_reduce(dst=row_max[:, :], op=nl.maximum, data=row_max_kv[:, :], axis=(1,))
 
@@ -450,23 +449,23 @@ def attn_fwd_v5(q, k, v):
         norm_row = nl.ndarray((PMAX, seqlen_kv),
                             dtype=nl.float32, buffer=nl.sbuf)
         for i_tile_kv in range(num_kv_tiles):
-            nisa.tensor_scalar(dst=norm_row[:, nl.ds(i_tile_kv*FMAX_MOVING, FMAX_MOVING)], 
+            nisa.tensor_scalar(dst=norm_row[:, i_tile_kv*FMAX_MOVING:i_tile_kv*FMAX_MOVING+FMAX_MOVING],
                 data=qk_tiles[i_tile_kv],
                 op0=nl.subtract,
                 operand0=row_max)
 
         # exponentiation
         exp_row = nl.ndarray((PMAX, seqlen_kv), dtype=nl.float32, buffer=nl.sbuf)
-        for i_tile_kv in nl.affine_range(seqlen_kv // FMAX_MOVING):
-            nisa.activation(dst=exp_row[:, nl.ds(i_tile_kv*FMAX_MOVING, FMAX_MOVING)], 
-                op=nl.exp, data=norm_row[:, nl.ds(i_tile_kv*FMAX_MOVING, FMAX_MOVING)])
+        for i_tile_kv in range(seqlen_kv // FMAX_MOVING):
+            nisa.activation(dst=exp_row[:, i_tile_kv*FMAX_MOVING:i_tile_kv*FMAX_MOVING+FMAX_MOVING],
+                op=nl.exp, data=norm_row[:, i_tile_kv*FMAX_MOVING:i_tile_kv*FMAX_MOVING+FMAX_MOVING])
 
         # sum of exp results
         sum_row_kv = nl.ndarray((PMAX, seqlen_kv // FMAX_MOVING), dtype=nl.float32, buffer=nl.sbuf)
-        for i_tile_kv in nl.affine_range(seqlen_kv // FMAX_MOVING):
-            nisa.tensor_reduce(dst=sum_row_kv[:, nl.ds(i_tile_kv, 1)], 
+        for i_tile_kv in range(seqlen_kv // FMAX_MOVING):
+            nisa.tensor_reduce(dst=sum_row_kv[:, i_tile_kv:i_tile_kv+1],
                 op=nl.add,
-                data=exp_row[:, nl.ds(i_tile_kv*FMAX_MOVING, FMAX_MOVING)], axis=(1,))
+                data=exp_row[:, i_tile_kv*FMAX_MOVING:i_tile_kv*FMAX_MOVING+FMAX_MOVING], axis=(1,))
 
         sum_row = nl.ndarray((PMAX, 1), dtype=nl.float32, buffer=nl.sbuf)
         nisa.tensor_reduce(dst=sum_row, op=nl.add, data=sum_row_kv, axis=(1,))
@@ -480,9 +479,9 @@ def attn_fwd_v5(q, k, v):
         # scores has the wrong layout
         scores_sbuf_t = nl.ndarray((PMAX, seqlen_kv // PMAX, PMAX),
                                     dtype=nl.float32, buffer=nl.sbuf)
-        for i_tile_kv in nl.affine_range(seqlen_kv // PMAX):
+        for i_tile_kv in range(seqlen_kv // PMAX):
             scores_psum_t = nl.ndarray((PMAX, PMAX), dtype=nl.float32, buffer=nl.psum)
-            nisa.nc_transpose(dst=scores_psum_t, data=exp_row[:, nl.ds(i_tile_kv*PMAX, PMAX)]) # TensorE
+            nisa.nc_transpose(dst=scores_psum_t, data=exp_row[:, i_tile_kv*PMAX:i_tile_kv*PMAX+PMAX]) # TensorE
             nisa.tensor_copy(dst=scores_sbuf_t[:, i_tile_kv, :], src=scores_psum_t)    # ScalarE
 
         # scores @ V, contract along seqlen_kv
@@ -491,19 +490,19 @@ def attn_fwd_v5(q, k, v):
 
         attn_out_psum = nl.zeros((PMAX, PMAX), dtype=nl.float32, buffer=nl.psum)
 
-        for i_tile_kv in nl.affine_range(seqlen_kv // PMAX): # loop on contraction
+        for i_tile_kv in range(seqlen_kv // PMAX): # loop on contraction
             nisa.nc_matmul(dst=attn_out_psum, stationary=scores_sbuf_t[:, i_tile_kv, :],
                                             moving=v_sbuf_t[:, i_tile_kv, :])
 
         # notice how here the division is done on the final attention output
-        # directly comparing to the previous implementation, we save on having to 
+        # directly comparing to the previous implementation, we save on having to
         # loop all the i_tile_kvs, meaning we do less divsion operations as our
         # attention block is already collapsed.
         nisa.tensor_scalar(dst=attn_out, data=attn_out_psum, op0=nl.multiply,
                                            operand0=inverse_sum_row)
 
         # store output
-        nl.store(dst=kernel_out[nl.ds(i_tile_q*PMAX, PMAX), :], value=attn_out[:, :])
+        nl.store(dst=kernel_out[i_tile_q*PMAX:i_tile_q*PMAX+PMAX, :], value=attn_out[:, :])
 
     return kernel_out
 
@@ -532,15 +531,15 @@ def attn_fwd_v6(q, k, v):
 
     # v has the wrong layout
     v_sbuf_t = nl.ndarray((PMAX, seqlen_kv // PMAX, PMAX), dtype=nl.float32, buffer=nl.sbuf)
-    for i_tile_kv in nl.affine_range(seqlen_kv // PMAX):
+    for i_tile_kv in range(seqlen_kv // PMAX):
         v_psum_t = nl.ndarray((PMAX, d_head), dtype=v_sbuf.dtype, buffer=nl.psum)
-        nisa.nc_transpose(dst=v_psum_t, data=v_sbuf[:, nl.ds(i_tile_kv*PMAX, PMAX)]) # TensorE
+        nisa.nc_transpose(dst=v_psum_t, data=v_sbuf[:, i_tile_kv*PMAX:i_tile_kv*PMAX+PMAX]) # TensorE
         nisa.tensor_copy(dst=v_sbuf_t[:, i_tile_kv, :], src=v_psum_t)     # ScalarE
 
     num_kv_tiles = seqlen_kv // FMAX_MOVING
 
     # Tile along seqlen_q #
-    for i_tile_q in nl.affine_range(seqlen_q // FMAX_STATIONARY): # loop on stationary_free
+    for i_tile_q in range(seqlen_q // FMAX_STATIONARY): # loop on stationary_free
         # Allocate fresh PSUM tiles each iteration to avoid accumulation
         qk_tiles = []
         for _i in range(num_kv_tiles):
@@ -548,9 +547,9 @@ def attn_fwd_v6(q, k, v):
 
         for i_tile_kv in range(num_kv_tiles): # loop on moving_free
             # Q @ K, contract along d_head #
-            nisa.nc_matmul(dst=qk_tiles[i_tile_kv], 
-                stationary=q_sbuf[0:PMAX, nl.ds(i_tile_q*FMAX_STATIONARY, FMAX_STATIONARY)],
-                moving=k_sbuf[0:PMAX, nl.ds(i_tile_kv*FMAX_MOVING, FMAX_MOVING)])
+            nisa.nc_matmul(dst=qk_tiles[i_tile_kv],
+                stationary=q_sbuf[0:PMAX, i_tile_q*FMAX_STATIONARY:i_tile_q*FMAX_STATIONARY+FMAX_STATIONARY],
+                moving=k_sbuf[0:PMAX, i_tile_kv*FMAX_MOVING:i_tile_kv*FMAX_MOVING+FMAX_MOVING])
 
         # Softmax #
         # reduce max along seqlen_k
@@ -558,7 +557,7 @@ def attn_fwd_v6(q, k, v):
 
         row_max_kv = nl.ndarray((PMAX, num_kv_tiles), dtype=nl.float32, buffer=nl.sbuf)
         for i_tile_kv in range(num_kv_tiles):
-            nisa.tensor_reduce(dst=row_max_kv[:, nl.ds(i_tile_kv, 1)], op=nl.maximum, data=qk_tiles[i_tile_kv], axis=(1,))
+            nisa.tensor_reduce(dst=row_max_kv[:, i_tile_kv:i_tile_kv+1], op=nl.maximum, data=qk_tiles[i_tile_kv], axis=(1,))
 
         nisa.tensor_reduce(dst=row_max[:, :], op=nl.maximum, data=row_max_kv[:, :], axis=(1,), negate=True)
 
@@ -566,19 +565,19 @@ def attn_fwd_v6(q, k, v):
         exp_row = nl.ndarray((PMAX, seqlen_kv),
                             dtype=nl.float32, buffer=nl.sbuf)
         sum_row_tiles = nl.ndarray((PMAX, num_kv_tiles), dtype=nl.float32, buffer=nl.sbuf)
-        
+
         # We leverage scalar engine's hardware capability of applying reduce after activation
-        # with no extra performance cost to compute the max_val subtraction and sum reduction 
+        # with no extra performance cost to compute the max_val subtraction and sum reduction
         # in one step, saving on extra loops that were previously required.
         #
         # At the same time the vector engine is freed up from compute, giving it more idle time
         for i_tile_kv in range(num_kv_tiles):
-            nisa.activation(dst=exp_row[:, nl.ds(i_tile_kv*FMAX_MOVING, FMAX_MOVING)], 
+            nisa.activation(dst=exp_row[:, i_tile_kv*FMAX_MOVING:i_tile_kv*FMAX_MOVING+FMAX_MOVING],
                 op=nl.exp,
                 data=qk_tiles[i_tile_kv],
                 bias=row_max,
                 reduce_op=nl.add,
-                reduce_res=sum_row_tiles[:, nl.ds(i_tile_kv, 1)],
+                reduce_res=sum_row_tiles[:, i_tile_kv:i_tile_kv+1],
                 reduce_cmd=nisa.reduce_cmd.reset_reduce
             )
         sum_row = nl.ndarray((PMAX, 1), dtype=nl.float32, buffer=nl.sbuf)
@@ -591,9 +590,9 @@ def attn_fwd_v6(q, k, v):
         # scores has the wrong layout
         scores_sbuf_t = nl.ndarray((PMAX, seqlen_kv // PMAX, PMAX),
                                     dtype=nl.float32, buffer=nl.sbuf)
-        for i_tile_kv in nl.affine_range(seqlen_kv // PMAX):
+        for i_tile_kv in range(seqlen_kv // PMAX):
             scores_psum_t = nl.ndarray((PMAX, PMAX), dtype=nl.float32, buffer=nl.psum)
-            nisa.nc_transpose(dst=scores_psum_t, data=exp_row[:, nl.ds(i_tile_kv*PMAX, PMAX)]) # TensorE
+            nisa.nc_transpose(dst=scores_psum_t, data=exp_row[:, i_tile_kv*PMAX:i_tile_kv*PMAX+PMAX]) # TensorE
             nisa.tensor_copy(dst=scores_sbuf_t[:, i_tile_kv, :], src=scores_psum_t)    # ScalarE
 
         # scores @ V, contract along seqlen_kv
@@ -602,7 +601,7 @@ def attn_fwd_v6(q, k, v):
 
         attn_out_psum = nl.zeros((PMAX, PMAX), dtype=nl.float32, buffer=nl.psum)
 
-        for i_tile_kv in nl.affine_range(seqlen_kv // PMAX): # loop on contraction
+        for i_tile_kv in range(seqlen_kv // PMAX): # loop on contraction
             nisa.nc_matmul(dst=attn_out_psum, stationary=scores_sbuf_t[:, i_tile_kv, :],
                                             moving=v_sbuf_t[:, i_tile_kv, :])
 
@@ -610,7 +609,7 @@ def attn_fwd_v6(q, k, v):
                                            operand0=inverse_sum_row)
 
         # store output
-        nl.store(dst=kernel_out[nl.ds(i_tile_q*PMAX, PMAX), :], value=attn_out[:, :])
+        nl.store(dst=kernel_out[i_tile_q*PMAX:i_tile_q*PMAX+PMAX, :], value=attn_out[:, :])
 
     return kernel_out
 
@@ -645,15 +644,15 @@ def attn_fwd_v7(q, k, v):
 
     # v has the wrong layout
     v_sbuf_t = nl.ndarray((PMAX, seqlen_kv // PMAX, PMAX), dtype=nl.bfloat16, buffer=nl.sbuf)
-    for i_tile_kv in nl.affine_range(seqlen_kv // PMAX):
+    for i_tile_kv in range(seqlen_kv // PMAX):
         v_psum_t = nl.ndarray((PMAX, d_head), dtype=v_sbuf.dtype, buffer=nl.psum)
-        nisa.nc_transpose(dst=v_psum_t, data=v_sbuf[:, nl.ds(i_tile_kv*PMAX, PMAX)]) # TensorE
+        nisa.nc_transpose(dst=v_psum_t, data=v_sbuf[:, i_tile_kv*PMAX:i_tile_kv*PMAX+PMAX]) # TensorE
         nisa.tensor_copy(dst=v_sbuf_t[:, i_tile_kv, :], src=v_psum_t)     # ScalarE
 
     num_kv_tiles = seqlen_kv // FMAX_MOVING
 
     # Tile along seqlen_q #
-    for i_tile_q in nl.affine_range(seqlen_q // FMAX_STATIONARY): # loop on stationary_free
+    for i_tile_q in range(seqlen_q // FMAX_STATIONARY): # loop on stationary_free
         # Allocate fresh PSUM tiles each iteration to avoid accumulation
         qk_tiles = []
         for _i in range(num_kv_tiles):
@@ -661,9 +660,9 @@ def attn_fwd_v7(q, k, v):
 
         for i_tile_kv in range(num_kv_tiles): # loop on moving_free
             # Q @ K, contract along d_head #
-            nisa.nc_matmul(dst=qk_tiles[i_tile_kv], 
-                stationary=q_sbuf[0:PMAX, nl.ds(i_tile_q*FMAX_STATIONARY, FMAX_STATIONARY)],
-                moving=k_sbuf[0:PMAX, nl.ds(i_tile_kv*FMAX_MOVING, FMAX_MOVING)])
+            nisa.nc_matmul(dst=qk_tiles[i_tile_kv],
+                stationary=q_sbuf[0:PMAX, i_tile_q*FMAX_STATIONARY:i_tile_q*FMAX_STATIONARY+FMAX_STATIONARY],
+                moving=k_sbuf[0:PMAX, i_tile_kv*FMAX_MOVING:i_tile_kv*FMAX_MOVING+FMAX_MOVING])
 
         # Softmax #
         # reduce max along seqlen_k
@@ -671,7 +670,7 @@ def attn_fwd_v7(q, k, v):
 
         row_max_kv = nl.ndarray((PMAX, num_kv_tiles), dtype=nl.float32, buffer=nl.sbuf)
         for i_tile_kv in range(num_kv_tiles):
-            nisa.tensor_reduce(dst=row_max_kv[:, nl.ds(i_tile_kv, 1)], op=nl.maximum, data=qk_tiles[i_tile_kv], axis=(1,))
+            nisa.tensor_reduce(dst=row_max_kv[:, i_tile_kv:i_tile_kv+1], op=nl.maximum, data=qk_tiles[i_tile_kv], axis=(1,))
 
         nisa.tensor_reduce(dst=row_max[:, :], op=nl.maximum, data=row_max_kv[:, :], axis=(1,), negate=True)
 
@@ -681,12 +680,12 @@ def attn_fwd_v7(q, k, v):
         sum_row_tiles = nl.ndarray((PMAX, num_kv_tiles), dtype=nl.float32, buffer=nl.sbuf)
 
         for i_tile_kv in range(num_kv_tiles):
-            nisa.activation(dst=exp_row[:, nl.ds(i_tile_kv*FMAX_MOVING, FMAX_MOVING)], 
+            nisa.activation(dst=exp_row[:, i_tile_kv*FMAX_MOVING:i_tile_kv*FMAX_MOVING+FMAX_MOVING],
                 op=nl.exp,
                 data=qk_tiles[i_tile_kv],
                 bias=row_max,
                 reduce_op=nl.add,
-                reduce_res=sum_row_tiles[:, nl.ds(i_tile_kv, 1)],
+                reduce_res=sum_row_tiles[:, i_tile_kv:i_tile_kv+1],
                 reduce_cmd=nisa.reduce_cmd.reset_reduce
             )
         sum_row = nl.ndarray((PMAX, 1), dtype=nl.float32, buffer=nl.sbuf)
@@ -699,9 +698,9 @@ def attn_fwd_v7(q, k, v):
         # scores has the wrong layout
         scores_sbuf_t = nl.ndarray((PMAX, seqlen_kv // PMAX, PMAX),
                                     dtype=nl.bfloat16, buffer=nl.sbuf)
-        for i_tile_kv in nl.affine_range(seqlen_kv // PMAX):
+        for i_tile_kv in range(seqlen_kv // PMAX):
             scores_psum_t = nl.ndarray((PMAX, PMAX), dtype=nl.bfloat16, buffer=nl.psum)
-            nisa.nc_transpose(dst=scores_psum_t, data=exp_row[:, nl.ds(i_tile_kv*PMAX, PMAX)]) # TensorE
+            nisa.nc_transpose(dst=scores_psum_t, data=exp_row[:, i_tile_kv*PMAX:i_tile_kv*PMAX+PMAX]) # TensorE
             nisa.tensor_copy(dst=scores_sbuf_t[:, i_tile_kv, :], src=scores_psum_t)    # ScalarE
 
         # scores @ V, contract along seqlen_kv
@@ -710,7 +709,7 @@ def attn_fwd_v7(q, k, v):
 
         attn_out_psum = nl.zeros((PMAX, PMAX), dtype=nl.float32, buffer=nl.psum)
 
-        for i_tile_kv in nl.affine_range(seqlen_kv // PMAX): # loop on contraction
+        for i_tile_kv in range(seqlen_kv // PMAX): # loop on contraction
             nisa.nc_matmul(dst=attn_out_psum, stationary=scores_sbuf_t[:, i_tile_kv, :],
                                             moving=v_sbuf_t[:, i_tile_kv, :])
 
@@ -718,7 +717,7 @@ def attn_fwd_v7(q, k, v):
                                            operand0=inverse_sum_row)
 
         # store output
-        nl.store(dst=kernel_out[nl.ds(i_tile_q*PMAX, PMAX), :], value=attn_out[:, :])
+        nl.store(dst=kernel_out[i_tile_q*PMAX:i_tile_q*PMAX+PMAX, :], value=attn_out[:, :])
 
     return kernel_out
 
@@ -727,8 +726,8 @@ def attn_fwd_v7(q, k, v):
 # v8: Use tensor_scalar_reduce on VectorE
 # In short, this evicts PSUM earlier allowing other Q@K tiles
 # to potentially be computed, freeing up the tensor engine to do
-# compute. This does lead to a slowdown compared to the v7 kernel, 
-# which is the fastest attention kernel we have thus far, but it 
+# compute. This does lead to a slowdown compared to the v7 kernel,
+# which is the fastest attention kernel we have thus far, but it
 # sets us up for software-pipelining and manual allocation, which
 # should outweight the cost penalty.
 ####################################################################
@@ -754,15 +753,15 @@ def attn_fwd_v8(q, k, v):
 
     # v has the wrong layout
     v_sbuf_t = nl.ndarray((PMAX, seqlen_kv // PMAX, PMAX), dtype=nl.bfloat16, buffer=nl.sbuf)
-    for i_tile_kv in nl.affine_range(seqlen_kv // PMAX):
+    for i_tile_kv in range(seqlen_kv // PMAX):
         v_psum_t = nl.ndarray((PMAX, d_head), dtype=v_sbuf.dtype, buffer=nl.psum)
-        nisa.nc_transpose(dst=v_psum_t, data=v_sbuf[:, nl.ds(i_tile_kv*PMAX, PMAX)]) # TensorE
+        nisa.nc_transpose(dst=v_psum_t, data=v_sbuf[:, i_tile_kv*PMAX:i_tile_kv*PMAX+PMAX]) # TensorE
         nisa.tensor_copy(dst=v_sbuf_t[:, i_tile_kv, :], src=v_psum_t)     # ScalarE
 
     num_kv_tiles = seqlen_kv // FMAX_MOVING
 
     # Tile along seqlen_q #
-    for i_tile_q in nl.affine_range(seqlen_q // FMAX_STATIONARY): # loop on stationary_free
+    for i_tile_q in range(seqlen_q // FMAX_STATIONARY): # loop on stationary_free
         # Allocate fresh PSUM tiles each iteration to avoid accumulation
         qk_tiles = []
         for _i in range(num_kv_tiles):
@@ -770,9 +769,9 @@ def attn_fwd_v8(q, k, v):
 
         for i_tile_kv in range(num_kv_tiles): # loop on moving_free
             # Q @ K, contract along d_head #
-            nisa.nc_matmul(dst=qk_tiles[i_tile_kv], 
-                stationary=q_sbuf[0:PMAX, nl.ds(i_tile_q*FMAX_STATIONARY, FMAX_STATIONARY)],
-                moving=k_sbuf[0:PMAX, nl.ds(i_tile_kv*FMAX_MOVING, FMAX_MOVING)])
+            nisa.nc_matmul(dst=qk_tiles[i_tile_kv],
+                stationary=q_sbuf[0:PMAX, i_tile_q*FMAX_STATIONARY:i_tile_q*FMAX_STATIONARY+FMAX_STATIONARY],
+                moving=k_sbuf[0:PMAX, i_tile_kv*FMAX_MOVING:i_tile_kv*FMAX_MOVING+FMAX_MOVING])
 
         # Softmax #
         # reduce max along seqlen_k
@@ -786,8 +785,8 @@ def attn_fwd_v8(q, k, v):
             qk_tile_sb = nl.ndarray((PMAX, FMAX_MOVING), dtype=nl.float32, buffer=nl.sbuf)
             nisa.tensor_copy(dst=qk_tile_sb, src=qk_tiles[i_tile_kv])
             nisa.tensor_scalar_reduce(dst=qk_sbuf[:, i_tile_kv, :], data=qk_tile_sb, op0=nl.multiply, operand0=1.0,
-                                                                    reduce_op=nl.maximum, reduce_res=row_max_kv[:, nl.ds(i_tile_kv, 1)])
-                                                                    
+                                                                    reduce_op=nl.maximum, reduce_res=row_max_kv[:, i_tile_kv:i_tile_kv+1])
+
         nisa.tensor_reduce(dst=row_max[:, :], op=nl.maximum, data=row_max_kv[:, :], axis=(1,), negate=True)
 
         # subtract max from row
@@ -796,12 +795,12 @@ def attn_fwd_v8(q, k, v):
         sum_row_tiles = nl.ndarray((PMAX, num_kv_tiles), dtype=nl.float32, buffer=nl.sbuf)
 
         for i_tile_kv in range(num_kv_tiles):
-            nisa.activation(dst=exp_row[:, nl.ds(i_tile_kv*FMAX_MOVING, FMAX_MOVING)], 
+            nisa.activation(dst=exp_row[:, i_tile_kv*FMAX_MOVING:i_tile_kv*FMAX_MOVING+FMAX_MOVING],
                 op=nl.exp,
                 data=qk_tiles[i_tile_kv],
                 bias=row_max,
                 reduce_op=nl.add,
-                reduce_res=sum_row_tiles[:, nl.ds(i_tile_kv, 1)],
+                reduce_res=sum_row_tiles[:, i_tile_kv:i_tile_kv+1],
                 reduce_cmd=nisa.reduce_cmd.reset_reduce
             )
         sum_row = nl.ndarray((PMAX, 1), dtype=nl.float32, buffer=nl.sbuf)
@@ -814,9 +813,9 @@ def attn_fwd_v8(q, k, v):
         # scores has the wrong layout
         scores_sbuf_t = nl.ndarray((PMAX, seqlen_kv // PMAX, PMAX),
                                     dtype=nl.bfloat16, buffer=nl.sbuf)
-        for i_tile_kv in nl.affine_range(seqlen_kv // PMAX):
+        for i_tile_kv in range(seqlen_kv // PMAX):
             scores_psum_t = nl.ndarray((PMAX, PMAX), dtype=nl.bfloat16, buffer=nl.psum)
-            nisa.nc_transpose(dst=scores_psum_t, data=exp_row[:, nl.ds(i_tile_kv*PMAX, PMAX)]) # TensorE
+            nisa.nc_transpose(dst=scores_psum_t, data=exp_row[:, i_tile_kv*PMAX:i_tile_kv*PMAX+PMAX]) # TensorE
             nisa.tensor_copy(dst=scores_sbuf_t[:, i_tile_kv, :], src=scores_psum_t)    # ScalarE
 
         # scores @ V, contract along seqlen_kv
@@ -825,7 +824,7 @@ def attn_fwd_v8(q, k, v):
 
         attn_out_psum = nl.zeros((PMAX, PMAX), dtype=nl.float32, buffer=nl.psum)
 
-        for i_tile_kv in nl.affine_range(seqlen_kv // PMAX): # loop on contraction
+        for i_tile_kv in range(seqlen_kv // PMAX): # loop on contraction
             nisa.nc_matmul(dst=attn_out_psum, stationary=scores_sbuf_t[:, i_tile_kv, :],
                                             moving=v_sbuf_t[:, i_tile_kv, :])
 
@@ -833,7 +832,7 @@ def attn_fwd_v8(q, k, v):
                                            operand0=inverse_sum_row)
 
         # store output
-        nl.store(dst=kernel_out[nl.ds(i_tile_q*PMAX, PMAX), :], value=attn_out[:, :])
+        nl.store(dst=kernel_out[i_tile_q*PMAX:i_tile_q*PMAX+PMAX, :], value=attn_out[:, :])
 
     return kernel_out
 
@@ -861,16 +860,16 @@ def attn_fwd_v8a(q, k, v):
 
     # v has the wrong layout
     v_sbuf_t = nl.ndarray((PMAX, seqlen_kv // PMAX, PMAX), dtype=nl.bfloat16, buffer=nl.sbuf)
-    for i_tile_kv in nl.affine_range(seqlen_kv // PMAX):
+    for i_tile_kv in range(seqlen_kv // PMAX):
         v_psum_t = nl.ndarray((PMAX, PMAX), dtype=v_sbuf.dtype, buffer=nl.psum)
-        nisa.nc_transpose(dst=v_psum_t, data=v_sbuf[:, nl.ds(i_tile_kv*PMAX, PMAX)])
+        nisa.nc_transpose(dst=v_psum_t, data=v_sbuf[:, i_tile_kv*PMAX:i_tile_kv*PMAX+PMAX])
         nisa.tensor_copy(dst=v_sbuf_t[:, i_tile_kv, :], src=v_psum_t)
 
     num_tile_q = seqlen_q // PMAX
     num_kv_tiles = seqlen_kv // FMAX_MOVING
 
     # Tile along seqlen_q #
-    for i_tile_q in nl.sequential_range(num_tile_q):
+    for i_tile_q in range(num_tile_q):
         # --- qk_max ---
         qk_tiles = []
         for _i in range(num_kv_tiles):
@@ -880,39 +879,39 @@ def attn_fwd_v8a(q, k, v):
         qk_sbuf_tiles = nl.ndarray((PMAX, num_kv_tiles, FMAX_MOVING), dtype=nl.float32, buffer=nl.sbuf)
         for i_tile_kv in range(num_kv_tiles):
             nisa.nc_matmul(dst=qk_tiles[i_tile_kv],
-                stationary=q_sbuf[0:PMAX, nl.ds(i_tile_q*PMAX, PMAX)],
-                moving=k_sbuf[0:PMAX, nl.ds(i_tile_kv*FMAX_MOVING, FMAX_MOVING)])
+                stationary=q_sbuf[0:PMAX, i_tile_q*PMAX:i_tile_q*PMAX+PMAX],
+                moving=k_sbuf[0:PMAX, i_tile_kv*FMAX_MOVING:i_tile_kv*FMAX_MOVING+FMAX_MOVING])
             qk_sb = nl.ndarray((PMAX, FMAX_MOVING), dtype=nl.float32, buffer=nl.sbuf)
             nisa.tensor_copy(dst=qk_sb, src=qk_tiles[i_tile_kv])
             nisa.tensor_scalar_reduce(dst=qk_sbuf_tiles[:, i_tile_kv, :], data=qk_sb,
                                       op0=nl.multiply, operand0=1.0,
                                       reduce_op=nl.maximum,
-                                      reduce_res=row_max_kv[:, nl.ds(i_tile_kv, 1)])
+                                      reduce_res=row_max_kv[:, i_tile_kv:i_tile_kv+1])
         row_max = nl.ndarray((PMAX, 1), dtype=nl.float32, buffer=nl.sbuf)
         nisa.tensor_reduce(dst=row_max, op=nl.maximum, data=row_max_kv, axis=(1,), negate=True)
 
         # --- exp_row_sum ---
         exp_row = nl.ndarray((PMAX, seqlen_kv), dtype=nl.bfloat16, buffer=nl.sbuf)
         sum_row_tiles = nl.ndarray((PMAX, num_kv_tiles), dtype=nl.float32, buffer=nl.sbuf)
-        for i_tile_kv in nl.affine_range(seqlen_kv // FMAX_MOVING):
-            nisa.activation(dst=exp_row[:, nl.ds(i_tile_kv*FMAX_MOVING, FMAX_MOVING)],
+        for i_tile_kv in range(seqlen_kv // FMAX_MOVING):
+            nisa.activation(dst=exp_row[:, i_tile_kv*FMAX_MOVING:i_tile_kv*FMAX_MOVING+FMAX_MOVING],
                 op=nl.exp,
                 data=qk_sbuf_tiles[:, i_tile_kv, :],
                 bias=row_max,
                 reduce_op=nl.add,
-                reduce_res=sum_row_tiles[:, nl.ds(i_tile_kv, 1)],
+                reduce_res=sum_row_tiles[:, i_tile_kv:i_tile_kv+1],
                 reduce_cmd=nisa.reduce_cmd.reset_reduce)
 
         # --- transpose_scores ---
         scores_sbuf_t = nl.ndarray((PMAX, seqlen_kv // PMAX, PMAX), dtype=nl.bfloat16, buffer=nl.sbuf)
-        for i_tile_kv in nl.affine_range(seqlen_kv // PMAX):
+        for i_tile_kv in range(seqlen_kv // PMAX):
             scores_psum_t = nl.ndarray((PMAX, PMAX), dtype=nl.bfloat16, buffer=nl.psum)
-            nisa.nc_transpose(dst=scores_psum_t, data=exp_row[:, nl.ds(i_tile_kv*PMAX, PMAX)])
+            nisa.nc_transpose(dst=scores_psum_t, data=exp_row[:, i_tile_kv*PMAX:i_tile_kv*PMAX+PMAX])
             nisa.tensor_copy(dst=scores_sbuf_t[:, i_tile_kv, :], src=scores_psum_t)
 
         # --- pv_matmul ---
         attn_out_psum = nl.zeros((PMAX, PMAX), dtype=nl.float32, buffer=nl.psum)
-        for i_tile_kv in nl.affine_range(seqlen_kv // PMAX):
+        for i_tile_kv in range(seqlen_kv // PMAX):
             nisa.nc_matmul(dst=attn_out_psum, stationary=scores_sbuf_t[:, i_tile_kv, :],
                                               moving=v_sbuf_t[:, i_tile_kv, :])
         attn_out_sbuf = nl.ndarray((PMAX, PMAX), dtype=nl.float32, buffer=nl.sbuf)
@@ -926,6 +925,231 @@ def attn_fwd_v8a(q, k, v):
         attn_out = nl.ndarray((PMAX, PMAX), dtype=nl.float32, buffer=nl.sbuf)
         nisa.tensor_scalar(dst=attn_out, data=attn_out_sbuf, op0=nl.multiply,
                            operand0=inverse_sum_row)
-        nl.store(dst=kernel_out[nl.ds(i_tile_q*PMAX, PMAX), :], value=attn_out)
+        nl.store(dst=kernel_out[i_tile_q*PMAX:i_tile_q*PMAX+PMAX, :], value=attn_out)
 
     return kernel_out
+
+####################################################################
+# v10 helper classes and functions
+####################################################################
+
+# Simple linear allocator, with no free/defrag
+class SBLinearAllocator(nl.NKIObject):
+    def __init__(self, start=0):
+        self.offset = start
+
+    # Try allocate size_bytes with alignment, returning address or assert fail if can't allocate
+    # Alignment of 32 bytes is needed for DMA transposes; use it as the default.
+    def allocate(self, size_bytes, alignment=32):
+        address = self.offset
+        self.offset = (self.offset + size_bytes + alignment - 1) & ~(alignment - 1)
+        assert (self.offset < nl.tile_size.sbuf_fmax_bytes), \
+                f"Can't allocate size {size_bytes} bytes anymore in SB which have total allocated {address} bytes!"
+        return address
+
+    # Get size in bytes of data type
+    def sizeinbytes(self, dtype):
+        if dtype == nl.float32:
+            return 4
+        elif dtype == nl.bfloat16:
+            return 2
+        else:
+            assert False, f"Unsupported dtype: {dtype}"
+
+    # Create SB ndarray with shape and data type
+    def create_ndarray(self, shape, dtype=nl.bfloat16):
+        size_bytes = self.sizeinbytes(dtype)
+        for x in shape[1:]:
+            size_bytes *= x
+        address = self.allocate(size_bytes)
+        return nl.ndarray(shape, dtype=dtype, buffer=nl.sbuf, address=(0, address))
+
+class PsumAllocator(nl.NKIObject):
+    def __init__(self, num_banks=8, bank_size=2048):
+        self.num_banks = num_banks
+        self.bank_size = bank_size
+
+    # Create PSUM bank of shape and data type
+    def create_ndarray(self, bank_idx, shape, dtype=nl.float32):
+        assert (bank_idx < self.num_banks), f"Bank index {bank_idx} requested is not within bank count of {self.num_banks}!"
+        assert (len(shape) == 2), "PSUM shapes limited to 2 dimensions"
+        return nl.ndarray(
+            shape,
+            dtype=dtype,
+            buffer=nl.psum,
+            address=(0, bank_idx * self.bank_size),
+        )
+
+class AttnInternalConfigs(nl.NKIObject):
+    seqlen_kv = None
+    num_tile_q = None
+    FMAX_MOVING = None
+
+class AttnInternalBuffers(nl.NKIObject):
+    q_sbuf = None
+    k_sbuf = None
+    v_sbuf = None
+    v_sbuf_t = None
+    v_psum_t = None
+    qk_sbuf = None
+    row_max_kv = None
+    row_max = None
+    exp_row = None
+    sum_row_tiles = None
+    sum_row = None
+    inverse_sum_row = None
+    scores_sbuf_t = None
+    attn_out = None
+    attn_out_sbuf = None
+    qk_psum = None
+    attn_out_psum = None
+    kernel_out = None
+
+def qk_max_2xbuf(i_tile_q, configs, bufs):
+    if (i_tile_q < 0 or i_tile_q > configs.num_tile_q -1):
+        return
+    # Note: QK and max are working on tile i_tile_q+2, while PV is working on tile i_tile_q
+    PMAX = nl.tile_size.pmax
+    FMAX_MOVING = configs.FMAX_MOVING
+    q_2xbuf_idx = i_tile_q % 2
+    for i_tile_kv in range(configs.seqlen_kv // FMAX_MOVING):
+        # QK psum banks wrap around at 7 since we reserve one psum bank for PV matmul 
+        qk_psum_bank = i_tile_kv % 7
+        # Q @ K, contract along d_head
+        nisa.nc_matmul(
+                dst=bufs.qk_psum[:, qk_psum_bank*FMAX_MOVING:qk_psum_bank*FMAX_MOVING+FMAX_MOVING],
+                stationary=bufs.q_sbuf[0:PMAX, i_tile_q*PMAX:i_tile_q*PMAX+PMAX],
+                moving=bufs.k_sbuf[0:PMAX, i_tile_kv*FMAX_MOVING:i_tile_kv*FMAX_MOVING+FMAX_MOVING], accumulate=False)
+
+        # Softmax, reduce max along seqlen_k
+        nisa.tensor_scalar_reduce(dst=bufs.qk_sbuf[:, q_2xbuf_idx, i_tile_kv, :],
+                                  data=bufs.qk_psum[:, qk_psum_bank*FMAX_MOVING:qk_psum_bank*FMAX_MOVING+FMAX_MOVING],
+                                  op0=nl.multiply,
+                                  operand0=1.0,
+                                  reduce_op=nl.maximum,
+                                  reduce_res=bufs.row_max_kv[:, i_tile_kv])
+
+    nisa.tensor_reduce(dst=bufs.row_max[:, :], op=nl.maximum, data=bufs.row_max_kv[:, :], axis=1, negate=True)
+
+# subtract max from row
+def exp_row_sum(i_tile_q, configs, bufs):
+    if (i_tile_q < 0 or i_tile_q > configs.num_tile_q -1):
+        return
+    FMAX_MOVING = configs.FMAX_MOVING
+    q_2xbuf_idx = i_tile_q % 2
+    for i_tile_kv in range(configs.seqlen_kv // FMAX_MOVING):
+        nisa.activation(
+            dst=bufs.exp_row[:, i_tile_kv*FMAX_MOVING:i_tile_kv*FMAX_MOVING+FMAX_MOVING],
+            op=nl.exp,
+            data=bufs.qk_sbuf[:, q_2xbuf_idx, i_tile_kv, :],
+            bias=bufs.row_max[:, :],
+            reduce_op=nl.add,
+            reduce_res=bufs.sum_row_tiles[:, q_2xbuf_idx, i_tile_kv],
+            reduce_cmd=nisa.reduce_cmd.reset_reduce,
+            )
+
+# scores has the wrong layout
+def transpose_scores(i_tile_q, configs, bufs):
+    if (i_tile_q < 0 or i_tile_q > configs.num_tile_q -1):
+        return
+    PMAX = nl.tile_size.pmax
+    for i_tile_kv in range(configs.seqlen_kv // PMAX):
+        nisa.dma_transpose(dst=bufs.scores_sbuf_t[:, i_tile_kv, :], src=bufs.exp_row[:, i_tile_kv*PMAX:i_tile_kv*PMAX+PMAX], axes=(1, 0))
+
+# scores @ V, contract along seqlen_kv
+def pv_matmul(i_tile_q, configs, bufs):
+    if (i_tile_q < 0 or i_tile_q > configs.num_tile_q - 1):
+        return
+    PMAX = nl.tile_size.pmax
+    for i_tile_kv in range(configs.seqlen_kv // PMAX):
+        nisa.nc_matmul(dst=bufs.attn_out_psum[:, :],
+                       stationary=bufs.scores_sbuf_t[:, i_tile_kv, :],
+                       moving=bufs.v_sbuf_t[:, i_tile_kv, :],
+                       accumulate=(i_tile_kv != 0))
+    nisa.tensor_copy(dst=bufs.attn_out_sbuf[:, :], src=bufs.attn_out_psum[:, :], engine=nisa.vector_engine)
+
+def write_back(i_tile_q, configs, bufs):
+    if (i_tile_q < 0 or i_tile_q > configs.num_tile_q -1):
+        return
+    PMAX = nl.tile_size.pmax
+    q_2xbuf_idx = i_tile_q % 2
+    nisa.tensor_reduce(dst=bufs.sum_row[:, :], op=nl.add, data=bufs.sum_row_tiles[:, q_2xbuf_idx, :], axis=1)
+
+    # reciprocal of sum_row [seqlen_q, 1]
+    nisa.reciprocal(dst=bufs.inverse_sum_row[:, :], data=bufs.sum_row[:, :])
+
+    nisa.tensor_scalar(dst=bufs.attn_out[:, :], data=bufs.attn_out_sbuf[:, :], op0=nl.multiply,
+                                    operand0=bufs.inverse_sum_row[:, :], engine=nisa.vector_engine)
+
+    # store output
+    nl.store(dst=bufs.kernel_out[i_tile_q*PMAX:i_tile_q*PMAX+PMAX, :], value=bufs.attn_out[:, :])
+
+####################################################################
+# v10: alloc & software pipelining scheduling
+####################################################################
+@nki.jit
+def attn_fwd_v10(q, k, v):
+    # Global singletons
+    sb = SBLinearAllocator()
+    psum = PsumAllocator()
+    bufs = AttnInternalBuffers()
+    configs = AttnInternalConfigs()
+
+    d_head, seqlen_q = q.shape
+    seqlen_kv = seqlen_q
+
+    PMAX = nl.tile_size.pmax
+    FMAX_MOVING = nl.tile_size.gemm_moving_fmax
+
+    assert q.shape == k.shape == v.shape
+    assert d_head == PMAX
+    assert seqlen_q >= FMAX_MOVING
+
+    configs.seqlen_kv = seqlen_kv
+    configs.num_tile_q = seqlen_q // PMAX
+    configs.FMAX_MOVING = FMAX_MOVING
+
+    bufs.kernel_out = nl.ndarray((seqlen_q, d_head), dtype=q.dtype, buffer=nl.shared_hbm)
+
+    bufs.q_sbuf = sb.create_ndarray((d_head, seqlen_q), dtype=q.dtype)
+    bufs.k_sbuf = sb.create_ndarray((d_head, seqlen_kv), dtype=k.dtype)
+    bufs.v_sbuf = sb.create_ndarray((d_head, seqlen_kv), dtype=v.dtype)
+
+    # load inputs into SBUF:
+    nisa.dma_copy(dst=bufs.q_sbuf, src=q)
+    nisa.dma_copy(dst=bufs.k_sbuf, src=k)
+    nisa.dma_copy(dst=bufs.v_sbuf, src=v)
+
+    # v has the wrong layout, so need to transpose it
+    bufs.v_sbuf_t = sb.create_ndarray((PMAX, seqlen_kv // PMAX, PMAX), dtype=nl.bfloat16)
+    bufs.v_psum_t = psum.create_ndarray(0, (PMAX, seqlen_kv), dtype=bufs.v_sbuf.dtype)
+    for i_tile_kv in range(seqlen_kv // PMAX):
+        nisa.nc_transpose(dst=bufs.v_psum_t[:, i_tile_kv*PMAX:i_tile_kv*PMAX+PMAX], data=bufs.v_sbuf[:, i_tile_kv*PMAX:i_tile_kv*PMAX+PMAX])
+        nisa.tensor_copy(dst=bufs.v_sbuf_t[:, i_tile_kv, :], src=bufs.v_psum_t[:, i_tile_kv*PMAX:i_tile_kv*PMAX+PMAX])
+
+    # SBUF allocations
+    bufs.qk_sbuf = sb.create_ndarray((PMAX, 2, seqlen_kv // FMAX_MOVING, FMAX_MOVING), dtype=nl.float32)
+    bufs.row_max_kv = sb.create_ndarray((PMAX, seqlen_kv // FMAX_MOVING), dtype=nl.float32)
+    bufs.row_max = sb.create_ndarray((PMAX, 1), dtype=nl.float32)
+    bufs.exp_row = sb.create_ndarray((PMAX, seqlen_kv), dtype=nl.bfloat16)
+    bufs.sum_row_tiles = sb.create_ndarray((PMAX, 2, seqlen_kv // FMAX_MOVING), dtype=nl.float32)
+    bufs.sum_row = sb.create_ndarray((PMAX, 1), dtype=nl.float32)
+    bufs.inverse_sum_row = sb.create_ndarray((PMAX, 1), dtype=nl.float32)
+    bufs.scores_sbuf_t = sb.create_ndarray((PMAX, seqlen_kv // PMAX, PMAX), dtype=nl.bfloat16)
+    bufs.attn_out = sb.create_ndarray((PMAX, PMAX), dtype=nl.float32)
+    bufs.attn_out_sbuf = sb.create_ndarray((PMAX, PMAX), dtype=nl.float32)
+
+    # PSUM allocations
+    bufs.qk_psum = psum.create_ndarray(0, (PMAX, 7*FMAX_MOVING))
+    bufs.attn_out_psum = psum.create_ndarray(7, (PMAX, PMAX))
+
+    # Tile along seqlen_q
+    with nl.no_reorder():
+        for i_tile_q in range(0, configs.num_tile_q + 2):
+            exp_row_sum(i_tile_q-1, configs, bufs)
+            qk_max_2xbuf(i_tile_q, configs, bufs)
+            pv_matmul(i_tile_q-2, configs, bufs)
+            transpose_scores(i_tile_q-1, configs, bufs)
+            write_back(i_tile_q-2, configs, bufs)
+
+    return bufs.kernel_out

--- a/src/nki_samples/tutorials/attention_fwd_performance/test_attention.py
+++ b/src/nki_samples/tutorials/attention_fwd_performance/test_attention.py
@@ -34,12 +34,18 @@ def numpy_attention(q, k, v):
 ####################################################################
 # Test each attention kernel version
 ####################################################################
-def test_attn_version(version, seqlen=1024):
+from ml_dtypes import bfloat16
+def test_attn_version(version, seqlen=1024, bf16_inputs=False):
     d_head = 128
     np.random.seed(42)
-    q = np.random.rand(d_head, seqlen).astype(np.float32)
-    k = np.random.rand(d_head, seqlen).astype(np.float32)
-    v = np.random.rand(d_head, seqlen).astype(np.float32)
+    if bf16_inputs:
+        q = np.random.rand(d_head, seqlen).astype(bfloat16)
+        k = np.random.rand(d_head, seqlen).astype(bfloat16)
+        v = np.random.rand(d_head, seqlen).astype(bfloat16)
+    else:
+        q = np.random.rand(d_head, seqlen).astype(np.float32)
+        k = np.random.rand(d_head, seqlen).astype(np.float32)
+        v = np.random.rand(d_head, seqlen).astype(np.float32)
 
     numpy_output = numpy_attention(q, k, v)
     attn_out = np.array(version(q, k, v))
@@ -55,6 +61,8 @@ if __name__ == "__main__":
     for v in [attn_fwd_v3, attn_fwd_v4, attn_fwd_v5, attn_fwd_v6,
               attn_fwd_v7, attn_fwd_v8, attn_fwd_v8a]:
         results.append(test_attn_version(v, seqlen=1024))
+    for v in [attn_fwd_v10]:
+        results.append(test_attn_version(v, seqlen=4096, bf16_inputs=True))
 
     passed = sum(results)
     total = len(results)


### PR DESCRIPTION
Updates the tutorial samples for the Neuron SDK 2.32 (NKI 0.6.0) release.

- Update the attention forward performance tutorial
- README fixes